### PR TITLE
fix: avoid native auto image sizes

### DIFF
--- a/src/lib/components/media/Image.svelte
+++ b/src/lib/components/media/Image.svelte
@@ -106,7 +106,7 @@
     srcSet={srcset}
     loading={lazy ? "lazy" : "eager"}
     fetchPriority={!lazy ? "high" : undefined}
-    sizes={sizes || (srcset && lazy ? "auto" : undefined)}
+    sizes={sizes || (srcset ? "100vw" : undefined)}
     {role}
   />
 {/snippet}


### PR DESCRIPTION
## Summary

- replace the automatic `sizes="auto"` fallback in the shared image component with `100vw` for `srcset` images
- keep explicitly provided `sizes` values unchanged

## Root Cause

Native `sizes="auto"` causes Chrome to apply a `contain-intrinsic-size` placeholder of `300px 150px`. For `w-full aspect-auto` images, that placeholder can win over the actual image dimensions and collapse wide images to a 150px rendered height.

## Validation

- `./node_modules/.bin/vitest run` passed: 10 files, 45 tests
- `./node_modules/.bin/prettier --check src/lib/components/media/Image.svelte` passed

Note: `npm run check` still reports existing `$env/static/private` export errors for `GQL_API_URL` and `GQL_API_TOKEN`, unrelated to this change.
