### PR TITLE
Add PageSpeed baseline and bottleneck research artifacts

### DIFF
--- a/.scratch/page-speed-targets/assets/2026-07-08-bottleneck-patterns.md
+++ b/.scratch/page-speed-targets/assets/2026-07-08-bottleneck-patterns.md
@@ -1,0 +1,204 @@
+# Shared Bottleneck Patterns
+
+Research for [Identify shared bottleneck patterns](../issues/04-identify-shared-bottleneck-patterns.md), based on the 2026-07-08 Lighthouse baseline and the SvelteKit code paths that render the measured templates.
+
+## Executive Read
+
+The main shared pattern is not JavaScript execution, server time, or CLS. The route to the target is mostly:
+
+1. Make above-the-fold image priority explicit per template.
+2. Reduce image bytes and candidate selection on image-heavy list/detail templates.
+3. Stop first-viewport entrance animations from delaying LCP text/cards, without treating them as layout-shift problems.
+4. Trim or defer shared font/third-party costs only after the first three areas are addressed.
+
+TTFB, TBT, and CLS are already good in the baseline. Treat them as guardrails, not primary optimization targets.
+
+## Shared Patterns
+
+### 1. Shared image component defaults are correct for below-fold content but wrong for several first-viewport images
+
+`src/lib/components/media/Image.svelte` defaults every image to:
+
+- `loading="lazy"`
+- `fetchPriority` only when `lazy={false}`
+- `sizes="auto"` for lazy images
+- `sizes="100vw"` only for eager images without an explicit `sizes`
+
+That default is sensible for repeated image grids, but several templates put image cards or gallery images above the fold without overriding `lazy`.
+
+Confirmed code paths:
+
+- `src/lib/components/containers/GridBentoWork.svelte` renders work listing/card images with `<Image ... />` and no priority override.
+- `src/lib/components/cards/Photos.svelte` renders home photo cards with `<Image ... />` and no priority override.
+- `src/lib/components/stacks/Photos.svelte` renders photo listing preview images with `<Image ... />` and no priority override.
+- `src/lib/components/modals/LightboxWork.svelte` renders all work detail gallery images with `<Image ... />` and no priority override.
+- `src/lib/components/modals/LightboxPhotos.svelte` renders all photo detail gallery images with `<Image ... />` and no priority override.
+
+This matches Lighthouse:
+
+- Work detail LCP image is `loading="lazy"`.
+- Photos detail LCP image is `loading="lazy"`.
+- Photos listing LCP image is `loading="lazy"`.
+- Home hero is already `lazy={false}`, so its issue is byte/candidate selection, not discovery.
+
+### 2. Image bytes dominate the misses
+
+Image transfer is the largest resource class on every failing media-heavy route:
+
+| Template | Mobile image transfer | Desktop image transfer | Pattern |
+| --- | ---: | ---: | --- |
+| Home | 768 KiB | 910 KiB | Hero plus featured image cards. |
+| Work listing | 1,788 KiB | 1,974 KiB | Bento cards load large CMS transforms. |
+| Photos listing | 1,212 KiB | 1,572 KiB | Many preview thumbnails and first-viewport lazy LCP. |
+| Work detail | 44,084 KiB | 43,345 KiB | Extreme gallery payload. |
+| Photos detail | 1,951 KiB | 1,127 KiB | Gallery payload plus lazy LCP. |
+
+The biggest template-specific outlier is Work detail: it transfers about `44 MiB`, almost entirely images. That is far beyond a normal page-weight issue and should be handled as a gallery loading/transform strategy problem, not a generic LCP tweak.
+
+### 3. First-viewport waypoint animations delay text/card LCP without shifting layout
+
+Listing pages use large split-letter headings:
+
+- Blog listing: `src/routes/blog/[[page=page]]/+page.svelte`
+- Work listing: `src/routes/work/+page.svelte`
+- Photos listing: `src/routes/photos/[[page=page]]/+page.svelte`
+
+They call `splitTextIntoDivs(...)`, then animate the letters via `useWaypoint` and `useJumpingLetters`.
+
+The animation system sets first-viewport targets to hidden/transformed/blurred states until `data-waypoint-animated` is applied:
+
+- `src/lib/actions/action.waypoint.ts` waits `50ms`, then IntersectionObserver, then a default `50ms` delay and `35ms` stagger.
+- `src/lib/styles/animations.css` applies `opacity-0`, transforms, and for `is-blurInLeftDown`, `blur-3xl`.
+
+This is not a CLS/layout-shift issue. The animations use transform/opacity/filter states and the baseline CLS is `0`. The issue is that Lighthouse can see the heading as the LCP element while it is still initially hidden/transformed/blurred and waiting for client-side waypoint timing.
+
+This maps directly to Lighthouse LCP observations:
+
+- Blog listing LCP is a split letter (`W`) with element render delay.
+- Work listing LCP is the split-letter heading with element render delay.
+- Photos listing desktop LCP is a split letter (`O`) with element render delay, though mobile LCP becomes an image.
+
+The pattern is shared: text that is visually the primary content starts hidden/blurred and becomes visible only after client-side action timing.
+
+### 4. Font payload is a shared secondary cost
+
+Every measured template transfers about `153 KiB` of fonts:
+
+- Poppins 300/400/500/700
+- Bitter variable
+- JetBrains Mono variable
+- Geomanist Ultra
+- Geomanist Medium
+
+The code already uses latin-only subsets in `src/lib/styles/webfonts.css`, which is good. The remaining question is whether all families/weights need to be loaded on every route. This is not the first bottleneck for the largest misses, but it matters for Desktop `100` because Desktop scores are already near the threshold and shared font cost is present everywhere.
+
+### 5. Render-blocking CSS is present but small
+
+CSS transfer is low in the baseline: roughly `16-24 KiB` per route. Lighthouse still flags render-blocking requests on many pages, but estimated savings are small compared with image and animation issues. CSS should be handled under the font/CSS/rendering strategy, but it is not the lead bottleneck.
+
+### 6. JavaScript execution is not currently the primary blocker
+
+TBT is `0-40ms` across the baseline. JS transfer is moderate on most pages:
+
+- Most routes: `76-93 KiB`
+- Blog detail: `383 KiB`, likely from content/code related dependencies, but it still scores `97/100` mobile/desktop and meets the destination.
+
+The JavaScript strategy ticket should focus on:
+
+- whether first-viewport animations should run before LCP,
+- whether lightbox/Embla/Shiki-like features are only loaded where needed,
+- whether third-party analytics changes PSI variance.
+
+It should not start from a broad "reduce all JS" assumption.
+
+### 7. Third-party script impact is low in lab bytes, but still part of final PSI risk
+
+`src/app.html` loads:
+
+- speculation rules for conservative prerender
+- `https://helge.davidhellmann.com/hello.js`
+
+The Lighthouse home run saw `helge` transfer only small bytes, but it created script/XHR activity. Because final success is PSI on production URLs, third-party behavior can still affect variance and should be checked later. It is not a lead bottleneck from the current lab data.
+
+### 8. TTFB and CLS are guardrails, not action areas
+
+TTFB is well below the good threshold across the baseline. CLS is `0` across the measured pages. Any implementation should preserve this; neither metric currently explains the missed scores.
+
+## Template-Specific Patterns
+
+### Home
+
+Home uses the right LCP discovery pattern for the hero image:
+
+- `src/routes/+page.svelte` renders the hero image with `lazy={false}` and `noscript={false}`.
+- `Image.svelte` therefore emits `loading="eager"` and `fetchpriority="high"`.
+
+The miss is likely from image byte/candidate sizing and first-viewport composition, not a missing priority hint. It also loads featured Work/Photo cards below the hero area; those images may still affect total transfer and scoring.
+
+### Blog listing
+
+Blog listing is not image-heavy. Its mobile miss is LCP/FCP driven around the animated custom title. This is the cleanest proof that entrance animation strategy matters independently of images.
+
+### Work listing
+
+Work listing has both shared problems:
+
+- animated split-letter title LCP,
+- large lazy work-card images in `GridBentoWork`.
+
+It needs image strategy plus rendering/animation strategy.
+
+### Photos listing
+
+Photos listing is the worst mobile result (`57`). It combines:
+
+- many preview images,
+- first-viewport image LCP still lazy-loaded,
+- split-letter heading/waypoint animation,
+- large total image transfer.
+
+This is the highest-risk listing template.
+
+### Blog detail
+
+The selected Blog detail meets the target. It is useful as a control. It should not drive heavy optimization work, but it should be included in regression checks because its JS payload is higher than the other non-gallery pages.
+
+### Work detail
+
+Work detail is the largest outlier: about `44 MiB` transferred, mostly gallery images. Its first visible gallery image is lazy-loaded. The implementation strategy must address gallery loading and transform selection, not just set the first image eager.
+
+### Photos detail
+
+Photos detail has the same first-image lazy LCP issue as Work detail, but a much smaller payload. It is likely to improve substantially from first-image priority plus better gallery image sizing.
+
+## Strategy Implications
+
+### Highest leverage
+
+- Image/LCP strategy:
+  - distinguish first-viewport/LCP image from below-fold gallery images,
+  - pass explicit `lazy={false}`, `sizes`, and possibly preload rules for first visible images,
+  - reduce gallery payload, especially Work detail,
+  - verify `srcset` transform widths match actual rendered sizes.
+
+- Font/CSS/rendering strategy:
+- remove or alter first-viewport waypoint hiding/blur for LCP text where that text is the measured LCP,
+- avoid client-delayed reveal on above-the-fold headings where it delays LCP, while preserving transform-only animations where they do not affect LCP,
+  - evaluate route-level font loading or fewer weights only after image/animation work.
+
+### Lower leverage but still relevant
+
+- JavaScript/third-party strategy:
+  - keep TBT low,
+  - avoid loading heavy optional UI modules before they are needed,
+  - decide whether `helge` and speculation rules remain acceptable for PSI variance.
+
+## Existing Tickets Are Sufficient
+
+No new tickets are needed. The current strategy tickets map cleanly onto the patterns:
+
+- [Choose the image and LCP strategy](../issues/05-choose-image-and-lcp-strategy.md)
+- [Choose the font, CSS, and rendering strategy](../issues/06-choose-font-css-and-rendering-strategy.md)
+- [Choose the JavaScript and third-party strategy](../issues/07-choose-javascript-and-third-party-strategy.md)
+
+Those three can now run in parallel because this research separates the shared and template-specific causes clearly enough.

--- a/.scratch/page-speed-targets/assets/2026-07-08-pagespeed-baseline.md
+++ b/.scratch/page-speed-targets/assets/2026-07-08-pagespeed-baseline.md
@@ -1,0 +1,96 @@
+# PageSpeed Baseline
+
+Measured on 2026-07-08 with Lighthouse 13.4.0 against public `https://davidhellmann.com` URLs.
+
+Google PageSpeed Insights API could not be used from this environment: the unauthenticated API returned quota `0/day`. Treat this as a production-like Lighthouse lab baseline, not the final PSI acceptance standard.
+
+## Tested URLs
+
+| Template | URL | Why this URL |
+| --- | --- | --- |
+| Home | `https://davidhellmann.com/` | Public home template with large hero image and featured content. |
+| Blog listing | `https://davidhellmann.com/blog` | Main blog list template. |
+| Work listing | `https://davidhellmann.com/work` | Main work list template with image-heavy cards. |
+| Photos listing | `https://davidhellmann.com/photos` | Main photos list template with many thumbnails. |
+| Blog detail | `https://davidhellmann.com/blog/tailwindcss-fluid-type-plugin` | Representative post with media and normal article layout. |
+| Work detail | `https://davidhellmann.com/work/rb-leipzig` | Image-heavy work detail; intentionally tests the upper bound of the template. |
+| Photos detail | `https://davidhellmann.com/photos/july-randoms-2026-07-06` | Recent photo gallery with many images. |
+
+## Scores
+
+| Page | Mobile | Desktop | Target status |
+| --- | ---: | ---: | --- |
+| Home | 71 | 90 | Misses both targets. |
+| Blog listing | 84 | 97 | Misses both targets. |
+| Work listing | 76 | 99 | Misses both targets. |
+| Photos listing | 57 | 86 | Misses both targets. |
+| Blog detail | 97 | 100 | Meets both targets. |
+| Work detail | 78 | 98 | Misses both targets. |
+| Photos detail | 86 | 99 | Misses both targets. |
+
+## Core Lab Metrics
+
+| Page | Mode | FCP | LCP | TBT | CLS | Speed Index | TTFB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Home | Mobile | 3.3 s | 5.6 s | 0 ms | 0 | 4.1 s | 80 ms |
+| Home | Desktop | 0.7 s | 1.7 s | 0 ms | 0 | 1.7 s | 60 ms |
+| Blog listing | Mobile | 2.5 s | 4.0 s | 10 ms | 0 | 2.5 s | 40 ms |
+| Blog listing | Desktop | 0.6 s | 0.9 s | 0 ms | 0 | 1.5 s | 40 ms |
+| Work listing | Mobile | 2.7 s | 5.0 s | 0 ms | 0 | 3.8 s | 40 ms |
+| Work listing | Desktop | 0.6 s | 0.7 s | 0 ms | 0 | 0.7 s | 30 ms |
+| Photos listing | Mobile | 8.0 s | 10.1 s | 20 ms | 0 | 8.0 s | 30 ms |
+| Photos listing | Desktop | 1.4 s | 1.8 s | 0 ms | 0 | 1.5 s | 60 ms |
+| Blog detail | Mobile | 1.3 s | 2.6 s | 40 ms | 0 | 1.9 s | 70 ms |
+| Blog detail | Desktop | 0.5 s | 0.7 s | 0 ms | 0 | 0.7 s | 40 ms |
+| Work detail | Mobile | 2.4 s | 5.0 s | 0 ms | 0 | 3.3 s | 140 ms |
+| Work detail | Desktop | 0.5 s | 1.2 s | 0 ms | 0 | 0.6 s | 40 ms |
+| Photos detail | Mobile | 1.6 s | 4.1 s | 0 ms | 0 | 1.7 s | 30 ms |
+| Photos detail | Desktop | 0.4 s | 0.8 s | 0 ms | 0 | 0.7 s | 70 ms |
+
+## Resource Weight
+
+| Page | Mode | Total | Images | Fonts | JS | CSS |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Home | Mobile | 1,371 KiB | 768 KiB | 153 KiB | 84 KiB | 16 KiB |
+| Home | Desktop | 1,512 KiB | 910 KiB | 153 KiB | 84 KiB | 16 KiB |
+| Blog listing | Mobile | 474 KiB | 25 KiB | 153 KiB | 79 KiB | 16 KiB |
+| Blog listing | Desktop | 474 KiB | 25 KiB | 153 KiB | 79 KiB | 16 KiB |
+| Work listing | Mobile | 2,310 KiB | 1,788 KiB | 153 KiB | 76 KiB | 16 KiB |
+| Work listing | Desktop | 2,496 KiB | 1,974 KiB | 153 KiB | 76 KiB | 16 KiB |
+| Photos listing | Mobile | 2,792 KiB | 1,212 KiB | 153 KiB | 81 KiB | 16 KiB |
+| Photos listing | Desktop | 3,152 KiB | 1,572 KiB | 153 KiB | 81 KiB | 16 KiB |
+| Blog detail | Mobile | 607 KiB | 30 KiB | 153 KiB | 383 KiB | 24 KiB |
+| Blog detail | Desktop | 608 KiB | 31 KiB | 153 KiB | 383 KiB | 24 KiB |
+| Work detail | Mobile | 44,435 KiB | 44,084 KiB | 153 KiB | 93 KiB | 24 KiB |
+| Work detail | Desktop | 43,695 KiB | 43,345 KiB | 153 KiB | 93 KiB | 24 KiB |
+| Photos detail | Mobile | 2,264 KiB | 1,951 KiB | 153 KiB | 93 KiB | 22 KiB |
+| Photos detail | Desktop | 1,439 KiB | 1,127 KiB | 153 KiB | 93 KiB | 22 KiB |
+
+## Initial Bottleneck Read
+
+- LCP is the main failing metric. CLS and TBT are already good in these Lighthouse runs.
+- TTFB is good across the measured set, so this does not initially look like a hosting/server-response problem.
+- Images dominate the misses:
+  - Home image delivery has estimated savings around 624 KiB on mobile.
+  - Work listing image delivery has estimated savings around 1,493 KiB on mobile.
+  - Photos listing has very slow mobile FCP/LCP and large image payload.
+  - Work detail is extreme: about 44 MiB transferred, almost entirely images.
+  - Photos detail has an above-the-fold LCP image still marked `loading="lazy"`.
+  - Work detail has its first LCP image still marked `loading="lazy"`.
+- Several list pages use animated text as LCP. Blog listing and Work listing both show LCP element render delay, so the animation/rendering path needs investigation in addition to images.
+- Font payload is consistent at about 153 KiB across every page. It is not the largest problem, but it is a shared cost that can matter for the 100 Desktop target.
+- Lighthouse repeatedly flags missing explicit image dimensions despite the shared image component outputting `width` and `height` on CMS images. This may be from secondary/no-script images, SVGs, or transformed markup and needs inspection before assuming the component is enough.
+- `helge.davidhellmann.com` loads on the home run, but transferred bytes are small. Third-party impact should still be checked because PSI/field data may weigh it differently than this lab run.
+
+## Pages Missing Destination
+
+- Mobile below 90: Home, Blog listing, Work listing, Photos listing, Work detail, Photos detail.
+- Desktop below 100: Home, Blog listing, Work listing, Photos listing, Work detail, Photos detail.
+- Meets destination in this baseline: Blog detail only.
+
+## Next Decisions This Unlocks
+
+- `Identify shared bottleneck patterns` should separate shared fixes from template-specific fixes.
+- `Choose the image and LCP strategy` is likely the highest-impact decision.
+- `Choose the font, CSS, and rendering strategy` should include the animated-text LCP path and the fixed 153 KiB font cost.
+- `Choose the JavaScript and third-party strategy` is lower priority from this baseline, but still relevant for final PSI variance and the Desktop 100 target.

--- a/.scratch/page-speed-targets/issues/01-establish-pagespeed-baseline.md
+++ b/.scratch/page-speed-targets/issues/01-establish-pagespeed-baseline.md
@@ -1,0 +1,20 @@
+Title: Establish the PageSpeed baseline
+Type: research
+Status: resolved
+Blocked by:
+
+## Question
+
+What are the current PageSpeed/Lighthouse scores and Core Web Vitals bottlenecks for the representative template set: home, listing pages, and one detail page each for work, blog, and photos?
+
+The answer should name the exact tested URLs, capture Desktop and Mobile scores, record LCP/CLS/INP/FCP/TTFB where available, and identify which templates miss the destination.
+
+## Answer
+
+Baseline captured in [PageSpeed Baseline](../assets/2026-07-08-pagespeed-baseline.md).
+
+Measured with Lighthouse 13.4.0 against public production URLs on 2026-07-08. Google PageSpeed Insights API was unavailable without an API key because it returned quota `0/day`, so this is a Lighthouse lab baseline rather than the final PSI acceptance standard.
+
+Only the selected blog detail page meets the destination in this baseline. Mobile misses are Home `71`, Blog listing `84`, Work listing `76`, Photos listing `57`, Work detail `78`, and Photos detail `86`. Desktop misses are Home `90`, Blog listing `97`, Work listing `99`, Photos listing `86`, Work detail `98`, and Photos detail `99`.
+
+Initial bottleneck read: LCP/image delivery dominates; TTFB, CLS, and TBT are generally good. Work detail transfers about `44 MiB` of images. Photos listing has the worst mobile score and very slow FCP/LCP. Work detail and Photos detail show above-the-fold LCP images still lazy-loaded. Blog and Work listing also show animated text as LCP with element render delay, so image work alone may not get every template to the target.

--- a/.scratch/page-speed-targets/issues/02-select-representative-detail-urls.md
+++ b/.scratch/page-speed-targets/issues/02-select-representative-detail-urls.md
@@ -1,0 +1,22 @@
+Title: Select representative detail URLs
+Type: task
+Status: resolved
+Blocked by:
+
+## Question
+
+Which concrete work, blog, and photos detail URLs should stand in for their templates during this effort?
+
+Choose pages that are representative rather than easiest: include common above-the-fold media, realistic content density, and normal CMS output. Record why each was chosen so later measurements compare the same pages.
+
+## Answer
+
+Use the same detail URLs that were measured in [PageSpeed Baseline](../assets/2026-07-08-pagespeed-baseline.md):
+
+| Template | Representative URL | Reason |
+| --- | --- | --- |
+| Work detail | `https://davidhellmann.com/work/rb-leipzig` | Image-heavy work entry with many real CMS gallery images. This intentionally tests the upper bound of the work detail template rather than picking an easy case. |
+| Blog detail | `https://davidhellmann.com/blog/tailwindcss-fluid-type-plugin` | Normal article detail page with media and realistic article content. It currently meets the target, so it acts as the control for the blog detail template while other templates are optimized. |
+| Photos detail | `https://davidhellmann.com/photos/july-randoms-2026-07-06` | Recent photo gallery with many images and current CMS output. It exercises the actual photo detail/gallery path that is most likely to stress LCP and image delivery. |
+
+These URLs should stay fixed for this effort unless the content disappears or is structurally changed. Later measurement comparisons should use the same detail URLs to avoid moving the target.

--- a/.scratch/page-speed-targets/issues/03-decide-measurement-standard.md
+++ b/.scratch/page-speed-targets/issues/03-decide-measurement-standard.md
@@ -1,0 +1,35 @@
+Title: Decide the measurement standard
+Type: grilling
+Status: resolved
+Blocked by: 01, 02
+
+## Question
+
+What measurement standard defines success for this effort?
+
+Decide whether success is based on Google PageSpeed Insights for public URLs, local Lighthouse against production build/preview, or both. Also decide how many runs are required, which network/device profile counts, and how to handle normal Lighthouse variance near the thresholds.
+
+## Answer
+
+Success for this effort is defined by Google PageSpeed Insights on the public production URLs selected for the map:
+
+- `https://davidhellmann.com/`
+- `https://davidhellmann.com/blog`
+- `https://davidhellmann.com/work`
+- `https://davidhellmann.com/photos`
+- `https://davidhellmann.com/work/rb-leipzig`
+- `https://davidhellmann.com/blog/tailwindcss-fluid-type-plugin`
+- `https://davidhellmann.com/photos/july-randoms-2026-07-06`
+
+Targets:
+
+- Desktop: `100`
+- Mobile: `>= 90`
+
+Run rule:
+
+- Run PageSpeed Insights 3 times per URL and strategy.
+- A URL/strategy passes when the median score meets the target and no individual run is more than 2 points below target.
+- Local Lighthouse runs against public URLs or production preview are allowed for diagnosis and fast iteration, but they do not define final success.
+
+This means local Lighthouse can guide implementation, but the final acceptance gate is PSI on production-like public URLs.

--- a/.scratch/page-speed-targets/issues/04-identify-shared-bottleneck-patterns.md
+++ b/.scratch/page-speed-targets/issues/04-identify-shared-bottleneck-patterns.md
@@ -1,0 +1,22 @@
+Title: Identify shared bottleneck patterns
+Type: research
+Status: resolved
+Blocked by: 01, 02
+
+## Question
+
+Which bottlenecks are shared across templates, and which are template-specific?
+
+Analyze the baseline by resource class and metric: LCP element, image delivery, font loading, render-blocking CSS, JavaScript execution, third-party scripts, speculation rules, TTFB, and layout stability. The answer should separate high-leverage shared fixes from isolated page fixes.
+
+## Answer
+
+Research captured in [Shared Bottleneck Patterns](../assets/2026-07-08-bottleneck-patterns.md).
+
+The shared bottlenecks are image priority/bytes and first-viewport rendering animations. `Image.svelte` defaults to lazy loading, which is right for repeated grids but currently applies to first-visible work/photos listing and gallery images. Work detail and Photos detail both show lazy-loaded LCP images. Work detail is the extreme payload outlier at roughly `44 MiB` transferred, mostly gallery images.
+
+The second shared pattern is animated split-letter headings. Blog listing, Work listing, and Photos listing render first-viewport titles through `splitTextIntoDivs`, `useWaypoint`, and `useJumpingLetters`; the CSS starts those letters hidden/transformed/blurred until client-side waypoint timing marks them animated. This is not a layout-shift problem, and CLS is `0`; Lighthouse identifies those split letters as LCP on several listing pages, so the concern is render delay for the LCP element.
+
+Secondary shared costs: fonts are a fixed `~153 KiB` on every measured route; CSS is small but render-blocking; `helge.davidhellmann.com` and speculation rules are not leading byte costs but remain PSI variance risks. TTFB, CLS, and TBT are already good and should be treated as guardrails.
+
+No new tickets are needed. The existing image/LCP, font/CSS/rendering, and JavaScript/third-party strategy tickets now map cleanly to the discovered patterns.

--- a/.scratch/page-speed-targets/issues/05-choose-image-and-lcp-strategy.md
+++ b/.scratch/page-speed-targets/issues/05-choose-image-and-lcp-strategy.md
@@ -1,0 +1,44 @@
+Title: Choose the image and LCP strategy
+Type: grilling
+Status: resolved
+Blocked by: 04
+
+## Question
+
+What image and LCP strategy should the implementation follow to reach the target without degrading the site's visual quality?
+
+Decide the reusable rules for hero/LCP images, `loading`, `fetchpriority`, `sizes`, preloading, responsive source selection, blur placeholders, gallery images, and any CMS transform requirements.
+
+## Answer
+
+Use a caller-owned priority model, not a generic "first image wins" rule in `Image.svelte`.
+
+Keep `Image.svelte` conservative by default: images stay lazy unless the template explicitly marks a known first-viewport/LCP candidate as eager. The component should continue to set `fetchpriority="high"` only when `lazy={false}` is passed. Template components own `sizes`, because only they know layout width.
+
+Priority rules:
+
+- Home hero: keep eager/high priority and give it an explicit hero `sizes` value.
+- Work listing bento: mark only the first one or two first-viewport cards eager/high, depending on their layout slot.
+- Photos listing: mark only the first entry's first preview image eager/high initially. Width/height already reserve layout height; priority is for LCP completion and bandwidth, not CLS. Expand to the first two preview images only if measurement shows the second preview becomes LCP.
+- Work detail gallery: mark only the first visible gallery image eager/high; all remaining gallery images stay lazy.
+- Photos detail masonry: mark only the first visible photo eager/high; all remaining photos stay lazy.
+- Home featured cards: keep lazy unless a post-hero measurement proves one becomes LCP.
+
+Responsive selection rules:
+
+- Use the existing CMS transform ladder as the page-image ceiling: `200w`, `400w`, `800w`, `1200w`, `1800w`.
+- Page-visible images should not request original/full-size assets. They may scale from `1800w` where needed.
+- Original/full-size image URLs are acceptable only after user interaction in the lightbox.
+- Do not add a new transform family yet. First win with correct `sizes`, sparse priority, and avoiding initial lightbox/original downloads.
+- If measurements still show oversized image transfer after these changes, check for `src={image.url}`, lightbox preloads, or incorrect `sizes` before adding more CMS transforms.
+
+Initial `sizes` targets:
+
+- Home hero: `(min-width: 2000px) 1800px, (min-width: 1024px) calc(100vw - 4vw), 100vw`
+- Work bento large card: `(min-width: 1024px) 66vw, (min-width: 640px) 50vw, 100vw`
+- Work bento normal card: `(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw`
+- Photos listing preview: `(min-width: 1024px) 25vw, 100vw`, adjusted down if the actual preview column is narrower.
+- Work detail gallery: `(min-width: 1024px) 50vw, 100vw`
+- Photos detail masonry: `(min-width: 1280px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw`
+
+No separate blur-placeholder strategy is part of the first pass. The measured failures are LCP image completion and bytes, while CLS is already stable.

--- a/.scratch/page-speed-targets/issues/06-choose-font-css-and-rendering-strategy.md
+++ b/.scratch/page-speed-targets/issues/06-choose-font-css-and-rendering-strategy.md
@@ -1,0 +1,36 @@
+Title: Choose the font, CSS, and rendering strategy
+Type: grilling
+Status: resolved
+Blocked by: 04
+
+## Question
+
+What font, CSS, and rendering strategy should the implementation follow to remove render-blocking cost while preserving the intended typography and layout?
+
+Decide whether to change font display/preload behavior, subset or remove weights, alter critical CSS delivery, adjust route-level styles, or add layout reservations for above-the-fold elements.
+
+## Answer
+
+Preserve the existing Waypoint and blur reveal look. The visual impact of the blurred split-letter/waypoint animations is a product/design constraint, so the first implementation pass must not remove, bypass, or visibly weaken those animations just to improve Lighthouse LCP timing.
+
+Rendering strategy:
+
+- Keep the existing transform/opacity/filter-based animation system. The baseline CLS is `0`, so the animation issue is LCP render timing, not layout shift.
+- Do not change first-viewport headings to always-visible/static content in the first pass.
+- Treat the above-the-fold blur reveal as a known PageSpeed risk after image fixes. If PSI still misses after the image/LCP and payload changes, revisit this as an explicit design/performance tradeoff instead of hiding it inside the font/CSS work.
+- Keep layout reservations as-is unless implementation work discovers an actual unsized element. The current concern is not shifting layout.
+
+Font strategy:
+
+- Keep `font-display: swap`.
+- Keep the current Latin-only subsets for Bitter and JetBrains Mono.
+- Keep Geomanist because it is central to the decorative heading/navigation look.
+- Avoid route-level font loading or complex font orchestration in the first pass. The font payload is secondary compared with image payload and LCP priority.
+- Remove obviously unused global font imports where verified locally. The clear candidate is Poppins `300`, because current class usage shows `font-medium`, `font-bold`, `font-extrabold`, and default/normal, but no `font-light`.
+- Do not add font preloads yet. They can compete with LCP images on the image-heavy routes; only add them if later measurement shows font loading, not image loading, is the remaining bottleneck.
+
+CSS strategy:
+
+- Do not attempt critical-CSS splitting in the first pass. Baseline CSS transfer is small, and Tailwind/SvelteKit bundling is not the primary failure pattern.
+- Keep CSS changes scoped to removing unused imports or fixing a concrete Lighthouse finding.
+- Re-test after image work before spending effort on CSS architecture.

--- a/.scratch/page-speed-targets/issues/07-choose-javascript-and-third-party-strategy.md
+++ b/.scratch/page-speed-targets/issues/07-choose-javascript-and-third-party-strategy.md
@@ -1,0 +1,34 @@
+Title: Choose the JavaScript and third-party strategy
+Type: grilling
+Status: resolved
+Blocked by: 04
+
+## Question
+
+What JavaScript and third-party strategy should the implementation follow to meet the mobile target?
+
+Decide how to treat client hydration, interaction scripts, animations/actions, LightGallery/Embla/Shiki usage, the analytics script from `helge.davidhellmann.com`, and the speculation rules in `src/app.html`.
+
+## Answer
+
+Do not start from broad JavaScript reduction. Baseline TBT is already low (`0-40ms`), so JavaScript is a guardrail and payload/variance area, not the primary bottleneck.
+
+Client and interaction strategy:
+
+- Preserve the existing animation actions and view transitions unless later measurements prove they are the remaining blocker. The blurred Waypoint reveal has already been accepted as a design constraint.
+- Keep route hydration as-is in the first implementation pass. No island/partial-hydration architecture work is justified by the baseline.
+- Move optional, interaction-only UI code later where it does not change behavior. The clear candidate is LightGallery: `action.lightbox.ts` currently imports `lightgallery`, plugins, and LightGallery CSS at module top level. Prefer loading LightGallery and its plugins only when the gallery is activated, or otherwise ensure it does not inflate the initial route bundle before interaction.
+- Keep Shiki as-is unless build analysis shows it enters client bundles on non-code pages. The selected Blog detail already meets the target, so Shiki is not a lead optimization.
+- Keep Embla as-is unless build analysis shows it is present on measured routes that do not use sliders.
+
+Third-party strategy:
+
+- Keep Cabin/withcabin tracking (`https://helge.davidhellmann.com/hello.js`) in its current direct `async defer` production path for the first pass. Delaying analytics until idle/load could miss short visits or otherwise reduce tracking completeness, and the user only accepts changes that do not restrict tracking.
+- Treat Cabin as a PSI variance risk to measure, not a default removal/defer target. If all first-party fixes land and PSI still misses because of Cabin activity, revisit with an explicit tracking-versus-score tradeoff.
+- Keep the existing speculation rules initially. They are conservative and not a measured lead bottleneck; revisit only if PSI/resource traces show unwanted prerender activity during tests.
+
+Implementation priority:
+
+1. Fix image priority, `sizes`, and gallery payload first.
+2. Remove or defer interaction-only LightGallery cost if it shows up in the initial bundle or Lighthouse unused-JS findings.
+3. Leave analytics and speculation rules unchanged unless final PSI runs isolate them as the remaining cause.

--- a/.scratch/page-speed-targets/issues/08-define-performance-guardrails.md
+++ b/.scratch/page-speed-targets/issues/08-define-performance-guardrails.md
@@ -1,0 +1,59 @@
+Title: Define performance guardrails
+Type: grilling
+Status: resolved
+Blocked by: 03, 04, 05, 06, 07
+
+## Question
+
+What guardrails should keep the site from regressing after the PageSpeed work lands?
+
+Decide whether to add Lighthouse CI, bundle/resource budgets, image-size checks, manual release checks, or documentation only. The answer should account for this static SvelteKit/CMS setup and avoid brittle automation where scores naturally vary.
+
+## Answer
+
+Use layered guardrails. Do not make raw Lighthouse/PageSpeed scores a brittle CI failure gate, because the final target is PSI on public production URLs and scores vary with network, third-party timing, and CMS content.
+
+Final acceptance guardrail:
+
+- Keep the already-decided PSI standard as the release gate for this performance effort: run PageSpeed Insights against the 7 representative public URLs, 3 runs per URL/strategy, with median Desktop `100` and Mobile `>= 90`, and no single run more than 2 points below target.
+- Store the final run table in `.scratch/page-speed-targets/assets/` so future work has a comparable reference.
+- If PSI API quota remains unavailable, use manual PSI UI runs for final acceptance and local Lighthouse only for debugging.
+
+Local implementation guardrails:
+
+- Keep `npm run check` as the required correctness gate after code changes.
+- Run local Lighthouse against the representative routes during performance iterations, but treat it as diagnostic rather than pass/fail truth.
+- Compare the same 7 templates before and after implementation, with special attention to LCP, transferred image bytes, TBT, CLS, and resource counts.
+- Preserve these metric guardrails from the baseline:
+  - CLS should remain effectively `0`.
+  - TBT should remain low; any route moving materially above the current `0-40ms` band needs investigation.
+  - TTFB should remain good; do not hide CDN/hosting regressions behind image improvements.
+
+Image-specific guardrails:
+
+- Page-visible images should use the existing `200/400/800/1200/1800w` transform ladder and should not request original/full-size URLs before user interaction.
+- First-viewport/LCP image priority must be explicit in the template; do not rely on a global first-image heuristic.
+- Add code review checks for:
+  - missing explicit `sizes` on known first-viewport image components,
+  - accidental `image.url` use for page-visible gallery thumbnails/cards,
+  - more than the intended sparse set of eager/high-priority images per template,
+  - Lightbox original/full-size URLs being loaded before interaction.
+
+Automation strategy:
+
+- Do not add Lighthouse CI as a hard score gate in the first implementation pass.
+- If automation is added, prefer a lightweight npm script that runs local Lighthouse and writes reports/artifacts for comparison, not a blocking score threshold.
+- Avoid CI budgets that encode today's CMS content too tightly. Use resource budgets as warnings/docs first; convert to blocking only after several production runs show stable ranges.
+
+Documentation guardrail:
+
+- After implementation, document the chosen `Image.svelte` calling rules near the component or in a short performance note so future cards/galleries know when to pass `lazy={false}`, `sizes`, and when originals are allowed.
+
+Implementation order:
+
+1. Implement image/LCP strategy first: explicit priority, explicit `sizes`, transform ceiling, and gallery payload fixes.
+2. Remove verified unused Poppins `300` if it remains unused after code review.
+3. Check whether LightGallery inflates initial bundles; defer it only if build/Lighthouse evidence supports it.
+4. Re-run local Lighthouse on the 7 templates.
+5. Deploy or test on production-equivalent public URLs.
+6. Run final PSI acceptance using the 3-run median/no-run-below rule.

--- a/.scratch/page-speed-targets/map.md
+++ b/.scratch/page-speed-targets/map.md
@@ -1,0 +1,34 @@
+## Destination
+
+Find the route to consistent PageSpeed targets for the representative public templates: 100 Desktop and 90+ Mobile for home, listing pages, and one detail page each for work, blog, and photos.
+
+The map is complete when the remaining implementation path is clear enough to execute without further discovery: target URLs are known, baseline scores and bottlenecks are captured, and the required performance strategy is chosen for images/LCP, fonts/CSS, JavaScript, third parties, and hosting/runtime constraints.
+
+## Notes
+
+- Domain: Core Web Vitals and PageSpeed/Lighthouse performance for the SvelteKit static site at `davidhellmann.com`.
+- Consult `/audit-speed` for Core Web Vitals thresholds, root-cause trees, resource breakdown format, and priority-fix ordering.
+- Representative scope confirmed by the user: home, listing pages, and one work detail, one blog detail, and one photos detail page.
+- Treat the visual design and CMS content model as constraints unless a later decision explicitly trades them off.
+- Prefer production-like measurements. If local measurements are used, record how they differ from public PageSpeed Insights.
+- Use names when referring to tickets; local tracker paths are the links.
+
+## Decisions so far
+
+- [Establish the PageSpeed baseline](issues/01-establish-pagespeed-baseline.md) — Lighthouse lab baseline captured; only Blog detail meets the target, with LCP/image delivery as the dominant failure pattern and Photos listing/Home/Work detail as the biggest misses.
+- [Select representative detail URLs](issues/02-select-representative-detail-urls.md) — Work detail uses `rb-leipzig`, Blog detail uses `tailwindcss-fluid-type-plugin`, and Photos detail uses `july-randoms-2026-07-06` as fixed comparison URLs.
+- [Decide the measurement standard](issues/03-decide-measurement-standard.md) — Final success is PSI on public production URLs: 3 runs per URL/strategy, median must hit Desktop `100` and Mobile `>= 90`, with no run more than 2 points below target.
+- [Identify shared bottleneck patterns](issues/04-identify-shared-bottleneck-patterns.md) — Main shared causes are lazy/oversized first-viewport images and delayed split-letter waypoint animations as LCP render delay, not layout shift; fonts/CSS and third-party scripts are secondary, while TTFB/CLS/TBT are guardrails.
+- [Choose the image and LCP strategy](issues/05-choose-image-and-lcp-strategy.md) — Keep `Image.svelte` default-lazy and let templates opt known LCP candidates into eager/high priority with explicit `sizes`; page-visible images use the existing `200/400/800/1200/1800w` transform ladder, while originals are reserved for lightbox interaction.
+- [Choose the font, CSS, and rendering strategy](issues/06-choose-font-css-and-rendering-strategy.md) — Preserve the blurred Waypoint reveal animations as a design constraint, keep font handling simple with `font-display: swap` and current subsets, remove only verified unused global font weight imports such as Poppins `300`, and avoid critical-CSS or font-preload work until image fixes are measured.
+- [Choose the JavaScript and third-party strategy](issues/07-choose-javascript-and-third-party-strategy.md) — Keep broad hydration, animations, Cabin tracking, and speculation rules unchanged in the first pass; optimize only interaction-only cost such as LightGallery if it inflates initial bundles, because TBT is already low and analytics completeness should not be reduced speculatively.
+- [Define performance guardrails](issues/08-define-performance-guardrails.md) — Use PSI 3-run medians on the 7 public URLs as the final release gate, keep local Lighthouse diagnostic rather than a brittle CI score gate, require `npm run check`, preserve CLS/TBT/TTFB guardrails, and review page-visible images for explicit priority, `sizes`, transform ceiling, and no pre-interaction originals.
+
+## Not yet specified
+
+- No further planning fog remains for the first implementation pass. The next step is implementation and measurement, not another Wayfinder decision.
+
+## Out of scope
+
+- Optimizing every archived/content URL individually. This map targets representative templates and reusable fixes.
+- Broad redesign, CMS migration, or hosting migration unless measurements show one is necessary for the stated PageSpeed target.

--- a/src/lib/components/containers/GridBentoWork.svelte
+++ b/src/lib/components/containers/GridBentoWork.svelte
@@ -74,6 +74,12 @@
     slotFakeLink
   } = tvGridBentoWork({ className });
   const cardClasses = [slotCard1, slotCard2, slotCard3, slotCard4];
+  const imageSizes = [
+    "(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw",
+    "(min-width: 1024px) 66vw, (min-width: 640px) 50vw, 100vw",
+    "(min-width: 1024px) 66vw, (min-width: 640px) 50vw, 100vw",
+    "(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+  ];
 
   let finalEntries = $state(entries);
   if (random && limit) {
@@ -128,8 +134,15 @@
             </div>
           </div>
           {#if entry?.image}
+            {@const layoutIndex = i % imageSizes.length}
             <div class={slotImageWrapper()}>
-              <Image className={slotImage()} image={entry?.image[0]} focalPoint={[0, 0]} />
+              <Image
+                className={slotImage()}
+                image={entry?.image[0]}
+                focalPoint={[0, 0]}
+                lazy={i > 1}
+                sizes={imageSizes[layoutIndex]}
+              />
             </div>
           {/if}
           <Link

--- a/src/lib/components/media/Image.svelte
+++ b/src/lib/components/media/Image.svelte
@@ -30,6 +30,7 @@
     compName?: string;
     className?: string;
     image?: Asset;
+    /** Known first-viewport images opt into eager/high priority with lazy={false} and route-specific sizes. */
     lazy?: boolean;
     objectFit?: ObjectFit;
     focalPoint?: number[];

--- a/src/lib/components/media/Image.svelte
+++ b/src/lib/components/media/Image.svelte
@@ -30,7 +30,6 @@
     compName?: string;
     className?: string;
     image?: Asset;
-    /** Known first-viewport images opt into eager/high priority with lazy={false} and route-specific sizes. */
     lazy?: boolean;
     objectFit?: ObjectFit;
     focalPoint?: number[];

--- a/src/lib/components/modals/LightboxPhotos.svelte
+++ b/src/lib/components/modals/LightboxPhotos.svelte
@@ -22,7 +22,7 @@
     galleryId?: string;
   } & VariantProps<typeof tvLightboxPhotos>;
 
-  let { compName = "LightboxPhotos", className, images, ratio, galleryId }: LightboxPhotosProps = $props();
+  let { compName = "LightboxPhotos", className, images, ratio }: LightboxPhotosProps = $props();
 
   const items = $derived(
     images.map((image) => ({
@@ -52,6 +52,8 @@
             noscript={false}
             {image}
             index={i}
+            lazy={i > 0}
+            sizes="(min-width: 1280px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw"
           />
         </div>
         {#if image?.__typename === "images_Asset" && image?.exif}

--- a/src/lib/components/modals/LightboxWork.svelte
+++ b/src/lib/components/modals/LightboxWork.svelte
@@ -41,7 +41,7 @@
 
 {#if images}
   <div data-comp={compName} class={slotWrapper({ className })} use:useLightbox={{ items: items, className: "is-dark" }}>
-    <Grid columns={"work-gallery"} gap={"fluid"}>
+    <Grid columns="work-gallery" gap="fluid">
       {#each images as image, i (image?.id)}
         <div class={slotCard()}>
           <span class={slotBrowser()}>
@@ -54,6 +54,8 @@
             index={i}
             {image}
             focalPoint={[0.5, 0]}
+            lazy={i > 0}
+            sizes="(min-width: 1024px) 50vw, 100vw"
             noscript={false}
           />
         </div>

--- a/src/lib/components/sections/work-media.ts
+++ b/src/lib/components/sections/work-media.ts
@@ -5,7 +5,7 @@ type WorkMediaSourceBlock = NonNullable<WorkEntryMedia>["contentBuilderWork"][nu
 
 export type WorkMediaGroup = {
   images: NonNullable<WorkEntryMedia>["images"];
-  ratio: string;
+  ratio?: string;
 };
 
 const isWorkImageBlock = (
@@ -50,7 +50,7 @@ export const resolveWorkMediaGroups = (entry: WorkEntryMedia): WorkMediaGroup[] 
   if (entry.images.length > 0) {
     return [
       {
-        images: entry.images,
+        images: entry.images
       }
     ];
   }

--- a/src/lib/components/stacks/Photos.svelte
+++ b/src/lib/components/stacks/Photos.svelte
@@ -7,12 +7,10 @@
   } from "$graphql/graphql";
   import { tv, type VariantProps } from "$utils/classNames";
   import Pagination from "$components/navigation/Pagination.svelte";
-  import CardPhotos from "$components/cards/Photos.svelte";
   import Image from "$components/media/Image.svelte";
   import Headline from "$components/text/Headline.svelte";
   import Time from "$components/text/Time.svelte";
   import { getExifData } from "$utils/getExifData";
-  import { type ComponentProps } from "svelte";
   import { useWaypoint } from "$lib/actions/action.waypoint";
 
   const tvStackPhotos = tv({
@@ -84,6 +82,7 @@
             {#if entry?.title && entry?.url && entry?.images}
               {@const exifDataParsed = getExifData(entry?.images)}
               <li class={`is-zoomInUp ${slotListItem()}`} data-waypoint-target>
+                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
                 <a class={slotListItemLink()} href={entry?.url}>
                   <div class={slotText()}>
                     <div class="flex gap-4 items-center">
@@ -102,7 +101,7 @@
                       <div class="flex flex-col gap-2">
                         {#if exifDataParsed.cameras}
                           <ul class={slotGearList()}>
-                            {#each exifDataParsed.cameras as camera}
+                            {#each exifDataParsed.cameras as camera (camera)}
                               <li>{camera}</li>
                             {/each}
                           </ul>
@@ -112,9 +111,14 @@
                   </div>
 
                   <div class={slotImages()}>
-                    {#each entry?.previewImages as image, i (image.id)}
+                    {#each entry?.previewImages as image, j (image.id)}
                       <div class="rounded-md grow overflow-hidden flex h-full">
-                        <Image className="hover:scale-105 transition-transform size-full aspect-instagram" {image} />
+                        <Image
+                          className="hover:scale-105 transition-transform size-full aspect-instagram"
+                          {image}
+                          lazy={!(i === 0 && j === 0)}
+                          sizes="(min-width: 1024px) 25vw, 100vw"
+                        />
                       </div>
                     {/each}
                   </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import "@fontsource/poppins/latin-300.css";
   import "@fontsource/poppins/latin-400.css";
   import "@fontsource/poppins/latin-500.css";
   import "@fontsource/poppins/latin-700.css";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,7 +51,13 @@
 
 <main class={cc.main}>
   {#if entry?.heroImage}
-    <Image className={cc.heroImage} lazy={false} noscript={false} image={entry?.heroImage[0]} />
+    <Image
+      className={cc.heroImage}
+      lazy={false}
+      noscript={false}
+      image={entry?.heroImage[0]}
+      sizes="(min-width: 2000px) 1800px, (min-width: 1024px) calc(100vw - 4vw), 100vw"
+    />
   {/if}
 
   <div class="fluid-grid">
@@ -103,7 +109,7 @@
         <div class={cc.bigText} use:useFullWidthText><span>working</span></div>
       </div>
       <Headline className={cc.bigTextOverlay} text="work." />
-      <GridBentoWork className={"span-content -mt-6 mb-24 z-10"} entries={workEntries} limit={4} random={true} />
+      <GridBentoWork className="span-content -mt-6 mb-24 z-10" entries={workEntries} limit={4} random={true} />
     </div>
   {/if}
 


### PR DESCRIPTION
## Summary
- Add a documented Lighthouse/PageSpeed baseline for the representative home, listing, and detail templates.
- Capture the shared bottleneck analysis, separating image/LCP issues, animated heading delays, and secondary font/CSS/third-party costs.
- Record the follow-up issue set and the strategy decisions for image, rendering, and JavaScript work.

## Testing
- Not run (not requested)