### PR TITLE
docs: define adapter-node migration planning map

### DIFF
--- a/.scratch/sveltekit-node-forge/issues/01-specify-rendering-boundary.md
+++ b/.scratch/sveltekit-node-forge/issues/01-specify-rendering-boundary.md
@@ -1,6 +1,6 @@
 Title: Specify the prerender and SSR boundary
 Type: grilling
-Status: open
+Status: resolved
 Blocked by:
 
 ## Question
@@ -8,3 +8,45 @@ Blocked by:
 What is the exact route-by-route rendering contract after the migration?
 
 Turn the standing preference—fixed top-level pages plus the first two pages of every paginated archive are prerendered, later archive pages and all detail pages are SSR—into an exhaustive route matrix. Resolve taxonomy archives, optional page parameters and canonical page-one redirects, generic CMS pages, Markdown endpoints, feeds, `llms` files, and static file responses. Define the required `prerender`, `entries`, and crawl behavior without implementing it.
+
+## Answer
+
+Use full runtime rendering through `adapter-node`. Code deployments and CMS publishing are separate lifecycles: publishing or changing Craft content must not require a SvelteKit deployment.
+
+### Route contract
+
+| Route family | Runtime contract |
+| --- | --- |
+| `/` | SSR; fetch the Home single at request time. |
+| `/about` | SSR; fetch the About single at request time. |
+| `/[uri]` | SSR for every published entry in Crafts `pages` section. No build-time enumeration. |
+| `/blog`, `/blog/<page>` | SSR for every archive page. `/blog/1` remains a runtime `301` to `/blog`; out-of-range behavior remains a runtime redirect. |
+| `/photos`, `/photos/<page>` | SSR for every archive page. `/photos/1` remains a runtime `301` to `/photos`; out-of-range behavior remains a runtime redirect. |
+| `/blog/c/<slug>[/<page>]` | SSR for every category and page. The `/1` alias and out-of-range behavior remain runtime redirects. |
+| `/blog/t/<slug>[/<page>]` | SSR for every topic and page. The `/1` alias and out-of-range behavior remain runtime redirects. |
+| `/blog/<slug>`, `/work/<slug>`, `/photos/<slug>` | SSR for all detail pages. Missing or unpublished content must produce the application's runtime not-found behavior. |
+| `/about.md`, `/blog/<slug>.md`, `/work/<slug>.md` | Render Markdown on demand through SSR. |
+| `/rss.xml`, `/llms.txt`, `/llms-full.txt` | Generate from current Craft content at request time. |
+| `/rss` | Keep the redirect behavior, but handle it at runtime too; its cost does not justify a separate rendering mode. |
+| `/[filename]` SEOmatic/front-end templates, sitemap files and styles | Resolve and serve from current Craft data at request time. |
+
+Static files in SvelteKits `static/` directory and generated client assets are still served as static assets by `adapter-node`; "full SSR" refers to application routes, not asset delivery.
+
+### SvelteKit configuration contract
+
+- Remove every route-level `export const prerender = true` for the application routes above, or replace it explicitly with `false` only where clarity warrants it. SvelteKits default is runtime rendering.
+- Remove every content `entries()` generator. Runtime routes no longer need Craft content enumerated during the build.
+- Remove the custom `kit.prerender.crawl: false` configuration because there is no application-route prerender set to control.
+- Remove the `adapter-static` fallback configuration; `adapter-node` handles runtime routes and 404 responses.
+- Do not use `prerender = "auto"`; there is intentionally no build-generated content subset.
+
+### Cache boundary
+
+- Remove the existing unbounded process-local cache in `src/lib/data/entries-cache.ts`; it would otherwise make SSR content stale until a process restart.
+- Initially use Crafts GraphQL cache as the only data-cache layer.
+- SvelteKit can emit response cache headers but `adapter-node` has no built-in persistent TTL cache or ISR. Experimental remote-function query caching is request-scoped on the server and does not provide this behavior. See [Loading data: Headers](https://svelte.dev/docs/kit/load#Headers), [Node servers](https://svelte.dev/docs/kit/adapter-node), and [Remote functions: Deduplication](https://svelte.dev/docs/kit/remote-functions#query-Deduplication).
+- Any later whole-response TTL, background refresh, or stale-on-error behavior belongs in Nginx and does not alter this SSR route contract.
+
+### Accepted trade-off
+
+All CMS-backed routes depend on Craft at request time. The user accepts initial request failure when Craft is unavailable; stale response serving may be added later through Nginx if staging justifies it.

--- a/.scratch/sveltekit-node-forge/issues/01-specify-rendering-boundary.md
+++ b/.scratch/sveltekit-node-forge/issues/01-specify-rendering-boundary.md
@@ -1,0 +1,10 @@
+Title: Specify the prerender and SSR boundary
+Type: grilling
+Status: open
+Blocked by:
+
+## Question
+
+What is the exact route-by-route rendering contract after the migration?
+
+Turn the standing preference—fixed top-level pages plus the first two pages of every paginated archive are prerendered, later archive pages and all detail pages are SSR—into an exhaustive route matrix. Resolve taxonomy archives, optional page parameters and canonical page-one redirects, generic CMS pages, Markdown endpoints, feeds, `llms` files, and static file responses. Define the required `prerender`, `entries`, and crawl behavior without implementing it.

--- a/.scratch/sveltekit-node-forge/issues/02-specify-release-and-environment-contract.md
+++ b/.scratch/sveltekit-node-forge/issues/02-specify-release-and-environment-contract.md
@@ -1,0 +1,10 @@
+Title: Specify the Node release and environment contract
+Type: grilling
+Status: open
+Blocked by:
+
+## Question
+
+What exactly must constitute a runnable, immutable `adapter-node` release, and which configuration belongs to build time, shared release state, or Node runtime?
+
+Specify the release directory contents, production dependency strategy, shared `.env` linkage, Node/pnpm versions, ownership and permissions, build-time `GQL_*` handling, runtime `HOST`/`PORT`/`ORIGIN` handling, and secrets separation between staging and production. Preserve the existing custom releases plus `current` symlink model.

--- a/.scratch/sveltekit-node-forge/issues/03-specify-staging-topology.md
+++ b/.scratch/sveltekit-node-forge/issues/03-specify-staging-topology.md
@@ -1,0 +1,10 @@
+Title: Specify the Forge staging topology
+Type: grilling
+Status: open
+Blocked by:
+
+## Question
+
+How should the required Forge staging site be isolated while remaining production-like enough to validate the migration?
+
+Decide its subdomain, filesystem roots, port, Supervisor process, Nginx site, environment/secrets, Craft endpoint and permissions, indexing/access protection, deployment branch, and how closely its infrastructure must mirror production. The result must make accidental public indexing, writes, or production-process interference unlikely.

--- a/.scratch/sveltekit-node-forge/issues/04-design-deployment-lifecycle.md
+++ b/.scratch/sveltekit-node-forge/issues/04-design-deployment-lifecycle.md
@@ -1,0 +1,10 @@
+Title: Design activation, healthcheck, and rollback
+Type: grilling
+Status: open
+Blocked by: 02, 03
+
+## Question
+
+What is the complete failure-safe lifecycle for building, activating, verifying, restarting, retaining, and rolling back a Node release within the existing custom deploy script?
+
+Specify ordering and failure behavior for dependency installation, build, release creation, shared-file linkage, symlink activation, Supervisor restart, readiness/health checking, automatic or manual rollback, cleanup of old releases, and deploys that exceed Forge's time limit. The answer should identify the last known-good release throughout the sequence.

--- a/.scratch/sveltekit-node-forge/issues/05-specify-runtime-and-proxy-contract.md
+++ b/.scratch/sveltekit-node-forge/issues/05-specify-runtime-and-proxy-contract.md
@@ -1,0 +1,10 @@
+Title: Specify the Supervisor and Nginx runtime contract
+Type: grilling
+Status: open
+Blocked by: 02, 03
+
+## Question
+
+How should Forge run and expose the `adapter-node` server in staging and production?
+
+Specify the Supervisor command, working directory, user, process count, signals, shutdown/start timeouts and logs; the loopback port and origin/proxy-header policy; Nginx proxy behavior, compression and static asset handling; healthcheck behavior; and the acceptable short restart window. Do not introduce HTML caching in the initial contract.

--- a/.scratch/sveltekit-node-forge/issues/06-validate-staging-migration.md
+++ b/.scratch/sveltekit-node-forge/issues/06-validate-staging-migration.md
@@ -1,10 +1,10 @@
 Title: Validate the migration on Forge staging
 Type: task
 Status: open
-Blocked by: 01, 04, 05
+Blocked by: 01, 04, 05, 09
 
 ## Question
 
 Run the implemented migration on the dedicated Forge staging site and collect the evidence needed for the production decision.
 
-Confirm repeated deployments below 10 minutes; verify the agreed prerender/SSR route matrix, direct loads, assets, redirects, canonicals, 404s and CMS freshness; test Supervisor restart, failed-start handling, healthcheck, and rollback; and measure representative cold/warm response behavior plus p95 TTFB and CMS load. Record exact URLs, commands, timings, and failures as the answer.
+Confirm repeated deployments below 10 minutes; verify the agreed SSR route matrix, direct loads, assets, redirects, canonicals, 404s and CMS freshness without a code deploy; test Supervisor restart, failed-start handling, healthcheck, and rollback; and measure representative cold/warm response behavior plus p95 TTFB and CMS load. Record exact URLs, commands, timings, and failures as the answer.

--- a/.scratch/sveltekit-node-forge/issues/06-validate-staging-migration.md
+++ b/.scratch/sveltekit-node-forge/issues/06-validate-staging-migration.md
@@ -1,0 +1,10 @@
+Title: Validate the migration on Forge staging
+Type: task
+Status: open
+Blocked by: 01, 04, 05
+
+## Question
+
+Run the implemented migration on the dedicated Forge staging site and collect the evidence needed for the production decision.
+
+Confirm repeated deployments below 10 minutes; verify the agreed prerender/SSR route matrix, direct loads, assets, redirects, canonicals, 404s and CMS freshness; test Supervisor restart, failed-start handling, healthcheck, and rollback; and measure representative cold/warm response behavior plus p95 TTFB and CMS load. Record exact URLs, commands, timings, and failures as the answer.

--- a/.scratch/sveltekit-node-forge/issues/07-decide-cache-fallback.md
+++ b/.scratch/sveltekit-node-forge/issues/07-decide-cache-fallback.md
@@ -1,0 +1,10 @@
+Title: Decide whether the Nginx cache fallback is needed
+Type: grilling
+Status: open
+Blocked by: 06
+
+## Question
+
+Does staging evidence justify adding an Nginx microcache, or should production initially rely only on Craft's warm GraphQL layer?
+
+Use the standing trigger of p95 TTFB above 500 ms or problematic CMS load. If caching is justified, specify a minimal public `GET`/`HEAD` policy with a short TTL, stale behavior, and bypasses for preview, authorization and relevant cookies; otherwise record why cache complexity should remain deferred.

--- a/.scratch/sveltekit-node-forge/issues/07-decide-cache-fallback.md
+++ b/.scratch/sveltekit-node-forge/issues/07-decide-cache-fallback.md
@@ -1,10 +1,10 @@
-Title: Decide whether the Nginx cache fallback is needed
+Title: Decide the Nginx response-cache policy
 Type: grilling
 Status: open
 Blocked by: 06
 
 ## Question
 
-Does staging evidence justify adding an Nginx microcache, or should production initially rely only on Craft's warm GraphQL layer?
+Does staging evidence and the desired content-freshness/resilience model justify adding an Nginx response cache, or should production initially rely only on Craft's warm GraphQL layer?
 
-Use the standing trigger of p95 TTFB above 500 ms or problematic CMS load. If caching is justified, specify a minimal public `GET`/`HEAD` policy with a short TTL, stale behavior, and bypasses for preview, authorization and relevant cookies; otherwise record why cache complexity should remain deferred.
+Consider p95 TTFB above 500 ms, problematic CMS load, desired per-route freshness windows, first-request population, background refresh, and stale-on-error behavior during a Craft outage. If caching is justified, specify a minimal public `GET`/`HEAD` policy with route-level TTLs and bypasses for preview, authorization and relevant cookies; otherwise record why cache complexity should remain deferred.

--- a/.scratch/sveltekit-node-forge/issues/08-decide-production-cutover.md
+++ b/.scratch/sveltekit-node-forge/issues/08-decide-production-cutover.md
@@ -1,0 +1,10 @@
+Title: Decide the production cutover and rollback runbook
+Type: grilling
+Status: open
+Blocked by: 06, 07
+
+## Question
+
+Given the staging evidence and cache decision, what exact runbook and go/no-go criteria should govern the production migration?
+
+Require deployment below 10 minutes; the correct prerender/SSR boundary and CMS freshness; correct direct requests, assets, redirects, canonicals and 404s; and a demonstrated healthcheck and rollback. Specify the production change order, smoke tests, observation window, abort conditions, rollback steps, and ownership of the final go/no-go decision.

--- a/.scratch/sveltekit-node-forge/issues/09-specify-runtime-data-access.md
+++ b/.scratch/sveltekit-node-forge/issues/09-specify-runtime-data-access.md
@@ -1,0 +1,10 @@
+Title: Specify the request-time Craft data-access contract
+Type: grilling
+Status: open
+Blocked by: 01
+
+## Question
+
+How should each SSR route query Craft after the unbounded process-local cache is removed?
+
+Specify which routes can use direct entry-by-slug or paginated GraphQL queries, which aggregated routes genuinely require complete collections, and how Home's random Work/Photo selections should behave. Avoid replacing the removed cache with full-collection fetches on every request by accident. Craft's GraphQL cache is the initial cache boundary; do not implement a new Node cache in this decision.

--- a/.scratch/sveltekit-node-forge/map.md
+++ b/.scratch/sveltekit-node-forge/map.md
@@ -1,0 +1,34 @@
+## Destination
+
+Create an implementation-ready specification for migrating this site from `adapter-static` to a mixed `adapter-node` deployment on Laravel Forge, covering the render boundary, caching, release/deployment lifecycle, runtime operation, rollback, staging validation, and production cutover.
+
+The map is complete when implementation can begin without further architectural or operational decisions and the resulting deployment is expected to remain reliably below Forge's 10-minute deployment limit.
+
+## Notes
+
+- Domain: SvelteKit mixed prerendering/SSR and operation of the Node server on the existing Laravel Forge host.
+- Start every session with [SvelteKit `adapter-node` auf Laravel Forge](../../docs/research/sveltekit-node-forge.md); it contains the local-system findings and primary-source research that established the feasible options.
+- Use `/grilling` and `/domain-modeling` for human decisions. Keep planning separate from implementation.
+- Preserve the existing custom release-directory and atomic `current`-symlink deployment model; adapt it for Node rather than replacing it with Forge's deployment model.
+- Rendering preference confirmed by the user: prerender fixed top-level entry pages and the first two pages of paginated archives; render later archive pages and all content detail pages through SSR.
+- Cache preference confirmed by the user: initially rely on Craft's warm GraphQL layer and add no Node, Nginx, CDN, or HTML cache. Consider an Nginx microcache only if staging/production-like measurement shows p95 TTFB above 500 ms or problematic CMS load.
+- A dedicated Forge staging site with its own subdomain, paths, port, Supervisor process, Nginx configuration, and environment is required before production cutover.
+- A brief restart window is acceptable; do not introduce blue/green processes or socket activation unless validation proves the simpler model inadequate.
+- Production cutover requires: deploy below 10 minutes; correct prerender/SSR boundary; correct CMS freshness; correct direct requests, assets, redirects, canonicals, and 404s; and tested healthcheck plus rollback.
+- Use ticket names in discussion; local tracker paths are the links.
+
+## Decisions so far
+
+<!-- Decisions are added here only when their tickets are resolved. -->
+
+## Not yet specified
+
+- The exact implementation sequence and commit breakdown should be derived only after the rendering, runtime, deployment, validation, and cutover contracts are resolved.
+- Longer-term observability and alerting may become specifiable after staging exposes the runtime's actual failure modes; only cutover-critical health checking belongs to this effort now.
+
+## Out of scope
+
+- Implementing the migration while charting this map.
+- Replacing Laravel Forge or introducing an external cache/CDN/service.
+- Guaranteed zero-downtime deployment unless staging demonstrates that the accepted short restart window is operationally unsafe.
+- Broad application refactors unrelated to the adapter migration and the routes affected by the render boundary.

--- a/.scratch/sveltekit-node-forge/map.md
+++ b/.scratch/sveltekit-node-forge/map.md
@@ -1,25 +1,27 @@
 ## Destination
 
-Create an implementation-ready specification for migrating this site from `adapter-static` to a mixed `adapter-node` deployment on Laravel Forge, covering the render boundary, caching, release/deployment lifecycle, runtime operation, rollback, staging validation, and production cutover.
+Create an implementation-ready specification for migrating this site from `adapter-static` to an `adapter-node` deployment on Laravel Forge, covering the render boundary, caching, release/deployment lifecycle, runtime operation, rollback, staging validation, and production cutover.
 
 The map is complete when implementation can begin without further architectural or operational decisions and the resulting deployment is expected to remain reliably below Forge's 10-minute deployment limit.
 
 ## Notes
 
-- Domain: SvelteKit mixed prerendering/SSR and operation of the Node server on the existing Laravel Forge host.
+- Domain: SvelteKit SSR through `adapter-node` and operation of the Node server on the existing Laravel Forge host.
 - Start every session with [SvelteKit `adapter-node` auf Laravel Forge](../../docs/research/sveltekit-node-forge.md); it contains the local-system findings and primary-source research that established the feasible options.
 - Use `/grilling` and `/domain-modeling` for human decisions. Keep planning separate from implementation.
 - Preserve the existing custom release-directory and atomic `current`-symlink deployment model; adapt it for Node rather than replacing it with Forge's deployment model.
-- Rendering preference confirmed by the user: prerender fixed top-level entry pages and the first two pages of paginated archives; render later archive pages and all content detail pages through SSR.
-- Cache preference confirmed by the user: initially rely on Craft's warm GraphQL layer and add no Node, Nginx, CDN, or HTML cache. Consider an Nginx microcache only if staging/production-like measurement shows p95 TTFB above 500 ms or problematic CMS load.
+- Rendering decision confirmed by the user: all routes are handled at runtime by `adapter-node`; code deployments must not be required to publish CMS content. Static assets remain static.
+- Cache preference confirmed by the user: remove the existing unbounded Node in-memory data cache and initially rely on Craft's warm GraphQL layer. SvelteKit has no persistent adapter-node ISR/page cache; consider Nginx response caching after staging for performance, controlled freshness, or stale-on-error resilience.
 - A dedicated Forge staging site with its own subdomain, paths, port, Supervisor process, Nginx configuration, and environment is required before production cutover.
 - A brief restart window is acceptable; do not introduce blue/green processes or socket activation unless validation proves the simpler model inadequate.
-- Production cutover requires: deploy below 10 minutes; correct prerender/SSR boundary; correct CMS freshness; correct direct requests, assets, redirects, canonicals, and 404s; and tested healthcheck plus rollback.
+- Production cutover requires: deploy below 10 minutes; correct SSR behavior and CMS freshness; correct direct requests, assets, redirects, canonicals, and 404s; and tested healthcheck plus rollback.
 - Use ticket names in discussion; local tracker paths are the links.
 
 ## Decisions so far
 
 <!-- Decisions are added here only when their tickets are resolved. -->
+
+- [Specify the prerender and SSR boundary](issues/01-specify-rendering-boundary.md) — Use full runtime rendering for every route, remove all content `entries()` generators and the prerender crawler configuration, and let code deploys remain independent of CMS publishing.
 
 ## Not yet specified
 


### PR DESCRIPTION
- Add migration decision tickets covering rendering, runtime, deployment, staging, caching, and cutover
- Document confirmed constraints and unresolved decisions for the Forge adapter-node migration