### PR TITLE
Normalize SplitText nodes before creating animations

### DIFF
--- a/src/lib/actions/action.splitText.test.ts
+++ b/src/lib/actions/action.splitText.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const splitTextCreate = vi.fn((node: HTMLElement) => {
+    const hasEmptyTextNode = Array.from(node.childNodes).some(
+      (child) => child.nodeType === 3 && child.textContent === ""
+    );
+
+    if (hasEmptyTextNode) {
+      throw new TypeError("Cannot read properties of undefined (reading 'charAt')");
+    }
+
+    return {
+      chars: [],
+      isSplit: true,
+      lines: [],
+      revert: vi.fn(),
+      words: []
+    };
+  });
+
+  return {
+    splitTextCreate,
+    timeline: vi.fn(() => ({
+      fromTo: vi.fn(),
+      kill: vi.fn(),
+      to: vi.fn()
+    }))
+  };
+});
+
+vi.mock("gsap", () => ({
+  gsap: {
+    registerPlugin: vi.fn(),
+    set: vi.fn(),
+    timeline: mocks.timeline,
+    utils: { random: vi.fn(() => 1) }
+  }
+}));
+
+vi.mock("gsap/SplitText", () => ({
+  SplitText: { create: mocks.splitTextCreate }
+}));
+
+import { useSplitText } from "./action.splitText";
+
+type TestNode = {
+  childNodes: Array<{ nodeType: number; textContent: string }>;
+  getBoundingClientRect: () => { height: number };
+  normalize: () => void;
+};
+
+class TestIntersectionObserver {
+  static current: TestIntersectionObserver | undefined;
+
+  private readonly callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    TestIntersectionObserver.current = this;
+  }
+
+  disconnect() {}
+
+  observe() {}
+
+  trigger() {
+    this.callback([{ isIntersecting: true } as IntersectionObserverEntry], this as unknown as IntersectionObserver);
+  }
+}
+
+describe("useSplitText", () => {
+  beforeEach(() => {
+    mocks.splitTextCreate.mockClear();
+    mocks.timeline.mockClear();
+    TestIntersectionObserver.current = undefined;
+
+    vi.stubGlobal("document", {
+      fonts: { ready: Promise.resolve() }
+    });
+    vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+    vi.stubGlobal("window", {
+      matchMedia: () => ({ matches: false })
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("removes empty SPA text nodes before handing the heading to SplitText", async () => {
+    const node: TestNode = {
+      childNodes: [
+        { nodeType: 3, textContent: "Work hard." },
+        { nodeType: 3, textContent: "" }
+      ],
+      getBoundingClientRect: () => ({ height: 120 }),
+      normalize() {
+        this.childNodes = this.childNodes.filter((child) => child.nodeType !== 3 || child.textContent !== "");
+      }
+    };
+
+    useSplitText(node as unknown as HTMLElement);
+    await Promise.resolve();
+
+    expect(() => TestIntersectionObserver.current?.trigger()).not.toThrow();
+    expect(mocks.splitTextCreate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/actions/action.splitText.ts
+++ b/src/lib/actions/action.splitText.ts
@@ -30,6 +30,10 @@ export function useSplitText(
   const play = () => {
     if (destroyed) return;
 
+    // Svelte can leave empty text nodes after client-side navigation. SplitText's
+    // custom word delimiter assumes every text node contains at least one word.
+    node.normalize();
+
     const naturalHeight = node.getBoundingClientRect().height;
 
     split = SplitText.create(node, {


### PR DESCRIPTION
## Summary

- Normalize heading text nodes before handing them to GSAP SplitText.
- Add a regression test covering empty text nodes left after client-side navigation.

## Testing

- Added a Vitest regression test for `useSplitText`.
- Not run (not requested).