### PR TITLE
Refactor content rendering and expose structured site content

### DIFF
--- a/src/lib/ai/about.ts
+++ b/src/lib/ai/about.ts
@@ -1,4 +1,4 @@
-import type { Page_AboutFragment } from "$graphql/graphql";
+import type { AboutEntry } from "$lib/types/content";
 import { SITE_URL, frontmatter, htmlBlock, join, linkMd } from "./helpers";
 
 type Award = {
@@ -19,7 +19,7 @@ type CvEntry = {
   company?: { title?: string | null }[] | null;
 };
 
-export const renderAbout = (entry: Page_AboutFragment): string => {
+export const renderAbout = (entry: AboutEntry): string => {
   const title = entry.customTitle?.trim() || entry.title?.trim() || "About";
   const description = entry.descriptionPlain?.trim();
 

--- a/src/lib/ai/blog.ts
+++ b/src/lib/ai/blog.ts
@@ -1,8 +1,8 @@
-import type { Page_BlogSingleFragment } from "$graphql/graphql";
+import type { BlogEntry } from "$lib/types/content";
 import { toDateTimeString } from "$lib/utils/date";
 import { SITE_URL, frontmatter, imageMd, renderBlocks, join } from "./helpers";
 
-export const renderBlog = (entry: Page_BlogSingleFragment): string => {
+export const renderBlog = (entry: BlogEntry): string => {
   const title = entry.customTitle?.trim() || entry.title?.trim() || "Untitled";
   const description = entry.descriptionPlain?.trim();
   const category = entry.category?.[0]?.title ?? null;

--- a/src/lib/ai/work.ts
+++ b/src/lib/ai/work.ts
@@ -1,8 +1,8 @@
-import type { Page_WorkSingleFragment } from "$graphql/graphql";
+import type { WorkEntry } from "$lib/types/content";
 import { toDateTimeString } from "$lib/utils/date";
 import { SITE_URL, frontmatter, imageMd, linkMd, renderBlocks, join } from "./helpers";
 
-export const renderWork = (entry: Page_WorkSingleFragment): string => {
+export const renderWork = (entry: WorkEntry): string => {
   const title = entry.customTitle?.trim() || entry.title?.trim() || "Untitled";
   const description = entry.descriptionPlain?.trim();
   const client = entry.client?.[0]?.title ?? null;

--- a/src/lib/components/builders/ContentBuilder.svelte
+++ b/src/lib/components/builders/ContentBuilder.svelte
@@ -7,7 +7,7 @@
   import Cta from "$components/builders/_blocks/Cta.svelte";
   import { getContentBlockKey, isContentBlockType, type ContentBuilderBlock } from "./content-blocks";
   import type { ComponentProps } from "svelte";
-  import type { Matrix_ContentBuilderFragment } from "$graphql/graphql";
+  import type { ContentBlock } from "$lib/types/content";
   import { cn } from "$utils/classNames";
 
   type ContentBuilder = {
@@ -16,8 +16,8 @@
     className?: string;
   };
 
-  type ImageBlock = Extract<Matrix_ContentBuilderFragment, { __typename: "block_image_Entry" }>;
-  type ImagesBlock = Extract<Matrix_ContentBuilderFragment, { __typename: "block_images_Entry" }>;
+  type ImageBlock = Extract<ContentBlock, { __typename: "block_image_Entry" }>;
+  type ImagesBlock = Extract<ContentBlock, { __typename: "block_images_Entry" }>;
 
   const { compName = "ContentBuilder", blockTypes, className }: ContentBuilder = $props();
 

--- a/src/lib/components/builders/_blocks/Cta.svelte
+++ b/src/lib/components/builders/_blocks/Cta.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Hyper_DataFragment } from "$lib/graphql/graphql";
+  import type { Hyperlink } from "$lib/types/content";
   import CtaWrapper from "$components/blocks/CtaWrapper.svelte";
   import Headline from "$components/text/Headline.svelte";
   import RichText from "$components/text/RichText.svelte";
@@ -13,7 +13,7 @@
     headline?: string;
     description?: string;
     icon?: HeroiconsIcons;
-    links: Hyper_DataFragment[];
+    links: Hyperlink[];
   };
 
   const { compName = "BlockCta", headline, description, icon = "face-smile-outline", links }: BlockCta = $props();

--- a/src/lib/components/builders/_blocks/Quote.svelte
+++ b/src/lib/components/builders/_blocks/Quote.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import type { Hyper_DataFragment } from "$lib/graphql/graphql";
+  import type { Hyperlink } from "$lib/types/content";
   import Quote from "$components/text/Quote.svelte";
 
   type BlockQuote = {
     compName?: string;
     quote: string;
     source?: string;
-    link?: Hyper_DataFragment | undefined;
+    link?: Hyperlink | undefined;
   };
 
   const { compName = "BlockQuote", quote, source, link }: BlockQuote = $props();

--- a/src/lib/components/builders/content-blocks.ts
+++ b/src/lib/components/builders/content-blocks.ts
@@ -1,14 +1,14 @@
-import type { Matrix_ContentBuilderFragment } from "$graphql/graphql";
+import type { ContentBlock } from "$lib/types/content";
 
-export type ContentBuilderBlock = Matrix_ContentBuilderFragment | Record<PropertyKey, never> | null | undefined;
+export type ContentBuilderBlock = ContentBlock | Record<PropertyKey, never> | null | undefined;
 
-export const isContentBlock = (block: ContentBuilderBlock): block is Matrix_ContentBuilderFragment =>
+export const isContentBlock = (block: ContentBuilderBlock): block is ContentBlock =>
   Boolean(block && "__typename" in block);
 
-export function isContentBlockType<TType extends Matrix_ContentBuilderFragment["__typename"]>(
+export function isContentBlockType<TType extends ContentBlock["__typename"]>(
   block: ContentBuilderBlock,
   type: TType
-): block is Extract<Matrix_ContentBuilderFragment, { __typename: TType }> {
+): block is Extract<ContentBlock, { __typename: TType }> {
   return isContentBlock(block) && block.__typename === type;
 }
 

--- a/src/lib/components/containers/GridBentoWork.svelte
+++ b/src/lib/components/containers/GridBentoWork.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { tv, type VariantProps } from "$utils/classNames";
-  import type { Page_WorkSingleFragment } from "$graphql/graphql";
+  import type { WorkEntry } from "$lib/types/content";
   import { getRandomItemsFromArray } from "$utils/getRandomItemsFromArray";
   import Image from "$components/media/Image.svelte";
   // import PlainText from "$components/text/PlainText.svelte";
@@ -12,7 +12,7 @@
   import { toDateTimeString } from "$utils/date";
   import type { ComponentProps } from "svelte";
 
-  type Entry = Page_WorkSingleFragment;
+  type Entry = WorkEntry;
 
   const tvGridBentoWork = tv({
     slots: {

--- a/src/lib/components/media/Image.svelte
+++ b/src/lib/components/media/Image.svelte
@@ -1,11 +1,7 @@
 <script module lang="ts">
-  import type { Asset_CustomFieldsFragment, Asset_DataFragment, Asset_TransformsFragment } from "$graphql/graphql";
+  import type { ImageAsset } from "$lib/types/content";
 
-  export type Asset = Asset_DataFragment &
-    Partial<Asset_TransformsFragment> &
-    Partial<Asset_CustomFieldsFragment> & {
-      __typename?: string;
-    };
+  export type Asset = ImageAsset;
 </script>
 
 <script lang="ts">

--- a/src/lib/components/navigation/PrevNext.svelte
+++ b/src/lib/components/navigation/PrevNext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { tv, type VariantProps } from "$utils/classNames";
   import IconSprite from "$components/media/IconSprite.svelte";
-  import type { Entry_DataFragment } from "$graphql/graphql";
+  import type { ContentLink } from "$lib/types/content";
 
   const tvPrevNext = tv({
     slots: {
@@ -37,8 +37,8 @@
   });
 
   type PrevNextProps = {
-    prev?: Entry_DataFragment;
-    next?: Entry_DataFragment;
+    prev?: ContentLink;
+    next?: ContentLink;
     compName?: string;
     className?: string;
   } & VariantProps<typeof tvPrevNext>;

--- a/src/lib/components/sections/CurriculumVitae.svelte
+++ b/src/lib/components/sections/CurriculumVitae.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { tv, type VariantProps } from "$utils/classNames";
-  import type { Matrix_CurriculumVitaeFragment } from "$graphql/graphql";
+  import type { CurriculumVitaeEntry } from "$lib/types/content";
   import CardCV from "$components/cards/CV.svelte";
 
   const tvCurriculumVitae = tv({
@@ -10,7 +10,7 @@
   type CurriculumVitaeProps = {
     compName?: string;
     className?: string;
-    items: Matrix_CurriculumVitaeFragment[];
+    items: CurriculumVitaeEntry[];
   } & VariantProps<typeof tvCurriculumVitae>;
 
   let { compName = "CurriculumVitae", className, items, ...rest }: CurriculumVitaeProps = $props();

--- a/src/lib/components/sections/WorkMedia.svelte
+++ b/src/lib/components/sections/WorkMedia.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import type { ComponentProps } from "svelte";
-  import type { Page_WorkSingleFragment } from "$graphql/graphql";
+  import type { WorkEntry } from "$lib/types/content";
   import LightboxWork from "$components/modals/LightboxWork.svelte";
   import { resolveWorkMediaGroups, type WorkMediaGroup } from "./work-media";
 
   type WorkMediaProps = {
     compName?: string;
-    entry?: Page_WorkSingleFragment;
+    entry?: WorkEntry;
   };
 
   const { compName = "WorkMedia", entry }: WorkMediaProps = $props();

--- a/src/lib/components/sections/work-media.ts
+++ b/src/lib/components/sections/work-media.ts
@@ -1,6 +1,6 @@
-import type { Page_WorkSingleFragment } from "$graphql/graphql";
+import type { WorkEntry } from "$lib/types/content";
 
-type WorkEntryMedia = Pick<Page_WorkSingleFragment, "contentBuilderWork" | "images"> | undefined;
+type WorkEntryMedia = Pick<WorkEntry, "contentBuilderWork" | "images"> | undefined;
 type WorkMediaSourceBlock = NonNullable<NonNullable<WorkEntryMedia>["contentBuilderWork"]>[number] | null | undefined;
 type WorkImages = NonNullable<NonNullable<WorkEntryMedia>["images"]>;
 

--- a/src/lib/components/stacks/Blog.svelte
+++ b/src/lib/components/stacks/Blog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Page_BlogSingleFragment } from "$graphql/graphql";
+  import type { BlogEntry } from "$lib/types/content";
   import { tv, type VariantProps } from "$utils/classNames";
   import Pagination from "$components/navigation/Pagination.svelte";
   import CardBlog from "$components/cards/Blog.svelte";
@@ -16,7 +16,7 @@
   type StackBlogProps = {
     compName?: string;
     className?: string;
-    entries: Page_BlogSingleFragment[];
+    entries: BlogEntry[];
     showPagination?: boolean;
     paginationUri?: string;
     totalItems?: number;

--- a/src/lib/components/stacks/Photos.svelte
+++ b/src/lib/components/stacks/Photos.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Page_PhotosSingleFragment } from "$graphql/graphql";
+  import type { PhotosEntry } from "$lib/types/content";
   import { tv, type VariantProps } from "$utils/classNames";
   import Pagination from "$components/navigation/Pagination.svelte";
   import Image from "$components/media/Image.svelte";
@@ -26,7 +26,7 @@
   type StackPhotosProps = {
     compName?: string;
     className?: string;
-    entries: Page_PhotosSingleFragment[];
+    entries: PhotosEntry[];
     showPagination?: boolean;
     totalItems?: number;
     totalPages?: number;

--- a/src/lib/components/stacks/Work.svelte
+++ b/src/lib/components/stacks/Work.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-  import type {
-    Entry_DataFragment,
-    Entry_DatesFragment,
-    Entry_SeoFragment,
-    Page_BlogSingleFragment
-  } from "$graphql/graphql";
+  import type { BlogEntry, ContentDates, ContentLink, ContentSeo } from "$lib/types/content";
   import { tv, type VariantProps } from "$utils/classNames";
   import Pagination from "$components/navigation/Pagination.svelte";
   import CardBlog from "$components/cards/Blog.svelte";
@@ -17,7 +12,7 @@
     }
   });
 
-  type Entry = Entry_DataFragment & Page_BlogSingleFragment & Entry_SeoFragment & Entry_DatesFragment;
+  type Entry = ContentLink & BlogEntry & ContentSeo & ContentDates;
 
   type StackWorkProps = {
     compName?: string;

--- a/src/lib/components/text/Quote.svelte
+++ b/src/lib/components/text/Quote.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { tv, type VariantProps } from "$utils/classNames";
   import Link from "$components/text/Link.svelte";
-  import type { Hyper_DataFragment } from "$graphql/graphql";
+  import type { Hyperlink } from "$lib/types/content";
   import type { ComponentProps } from "svelte";
 
   const tvQuote = tv({
@@ -22,7 +22,7 @@
     className?: string;
     quote: string;
     source?: string;
-    link?: Hyper_DataFragment | undefined;
+    link?: Hyperlink | undefined;
   } & VariantProps<typeof tvQuote>;
 
   const { compName = "Quote", className, quote, source, link }: QuoteProps = $props();

--- a/src/lib/data/about.ts
+++ b/src/lib/data/about.ts
@@ -1,9 +1,1 @@
-import { GetAboutEntryDocument, type Page_AboutFragment, type GetAboutEntryQueryVariables } from "$graphql/graphql";
-import { getGqlData } from "$graphql/graphql-client";
-
-export const getAboutEntry = async (): Promise<Page_AboutFragment | null> => {
-  const { entries } = (await getGqlData<GetAboutEntryQueryVariables>(GetAboutEntryDocument, {})) as {
-    entries?: Page_AboutFragment[];
-  };
-  return entries?.[0] ?? null;
-};
+export { getAbout as getAboutEntry } from "$graphql/cms-content";

--- a/src/lib/graphql/cms-content.ts
+++ b/src/lib/graphql/cms-content.ts
@@ -2,81 +2,63 @@ import {
   type GetBlogEntriesQueryVariables,
   type GetPhotosEntriesQueryVariables,
   type GetSeomaticQueryVariables,
-  type GetWorkEntriesQueryVariables,
-  type Page_BlogSingleFragment,
-  type Page_PhotosSingleFragment,
-  type Page_WorkSingleFragment
+  type GetWorkEntriesQueryVariables
 } from "$graphql/graphql";
 import { cmsSdk, type PreviewTokens } from "$graphql/graphql-client";
+import { getEntriesOfType, getEntryOfType } from "$graphql/entry-type";
 
 const sdk = (tokens?: PreviewTokens) => cmsSdk(tokens ?? {});
 
-export const getHomeEntries = async (tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetHomeEntry({})).entries;
+export const getHome = async (tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetHomeEntry({})).entries, "page_home_Entry");
 
-export const getAboutEntries = async (tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetAboutEntry({})).entries;
+export const getAbout = async (tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetAboutEntry({})).entries, "page_about_Entry");
 
-export const getPageByUriEntries = async (uri: string | undefined, tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetPageByUri({ uri: [uri] })).entries;
+export const getPageByUri = async (uri: string, tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetPageByUri({ uri: [uri] })).entries, "page_contentBuilder_Entry");
 
-export const getBlogListPageEntries = async (tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetBlogListPage({})).entries;
+export const getBlogList = async (tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetBlogListPage({})).entries, "page_blogList_Entry");
 
-export const getPhotosListPageEntries = async (tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetPhotosListPage({})).entries;
+export const getPhotosList = async (tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetPhotosListPage({})).entries, "page_photosList_Entry");
 
-export const getWorkListPageEntries = async (tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetWorkListPage({})).entries;
+export const getWorkList = async (tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetWorkListPage({})).entries, "page_workList_Entry");
 
-const isEntryType = <TEntry extends { __typename: string }>(
-  entry: Record<PropertyKey, never> | TEntry,
-  typename: TEntry["__typename"]
-): entry is TEntry => "__typename" in entry && entry.__typename === typename;
-
-export const getBlogEntriesData = async (
-  variables: GetBlogEntriesQueryVariables,
-  tokens?: PreviewTokens
-) => {
+export const getBlogPosts = async (variables: GetBlogEntriesQueryVariables, tokens?: PreviewTokens) => {
   const data = await sdk(tokens).GetBlogEntries(variables);
 
   return {
     ...data,
-    entries: data.entries.filter((entry) => isEntryType<Page_BlogSingleFragment>(entry, "page_blogSingle_Entry"))
+    entries: getEntriesOfType(data.entries, "page_blogSingle_Entry")
   };
 };
 
-export const getPhotosEntriesData = async (
-  variables: GetPhotosEntriesQueryVariables,
-  tokens?: PreviewTokens
-) => {
+export const getPhotoGalleries = async (variables: GetPhotosEntriesQueryVariables, tokens?: PreviewTokens) => {
   const data = await sdk(tokens).GetPhotosEntries(variables);
 
   return {
     ...data,
-    entries: data.entries.filter((entry) => isEntryType<Page_PhotosSingleFragment>(entry, "page_photosSingle_Entry"))
+    entries: getEntriesOfType(data.entries, "page_photosSingle_Entry")
   };
 };
 
-export const getWorkEntriesData = async (
-  variables: GetWorkEntriesQueryVariables,
-  tokens?: PreviewTokens
-) => {
+export const getWorkProjects = async (variables: GetWorkEntriesQueryVariables, tokens?: PreviewTokens) => {
   const data = await sdk(tokens).GetWorkEntries(variables);
 
   return {
     ...data,
-    entries: data.entries.filter((entry) => isEntryType<Page_WorkSingleFragment>(entry, "page_workSingle_Entry"))
+    entries: getEntriesOfType(data.entries, "page_workSingle_Entry")
   };
 };
 
-export const getCategoryEntries = async (slug: string | undefined, tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetCategoryEntry({ slug: [slug] })).entries;
+export const getBlogCategory = async (slug: string, tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetCategoryEntry({ slug: [slug] })).entries, "page_category_Entry");
 
-export const getTopicEntries = async (slug: string | undefined, tokens?: PreviewTokens) =>
-  (await sdk(tokens).GetTopicEntry({ slug: [slug] })).entries;
+export const getBlogTopic = async (slug: string, tokens?: PreviewTokens) =>
+  getEntryOfType((await sdk(tokens).GetTopicEntry({ slug: [slug] })).entries, "page_topic_Entry");
 
-export const getSeomaticData = (
-  variables: GetSeomaticQueryVariables,
-  tokens?: PreviewTokens
-) => sdk(tokens).GetSeomatic(variables);
+export const getSeomaticData = (variables: GetSeomaticQueryVariables, tokens?: PreviewTokens) =>
+  sdk(tokens).GetSeomatic(variables);

--- a/src/lib/graphql/entry-type.test.ts
+++ b/src/lib/graphql/entry-type.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getEntriesOfType, getEntryOfType } from "./entry-type";
+
+type TestEntry =
+  | Record<PropertyKey, never>
+  | { __typename: "page_company_Entry"; id: string }
+  | { __typename: "page_home_Entry"; id: string }
+  | { __typename: "page_blogSingle_Entry"; id: string };
+
+describe("getEntryOfType", () => {
+  it("returns the first entry with the requested CMS type", () => {
+    const entries: TestEntry[] = [
+      {},
+      { __typename: "page_company_Entry", id: "company" },
+      { __typename: "page_home_Entry", id: "home" }
+    ];
+
+    expect(getEntryOfType(entries, "page_home_Entry")).toEqual({
+      __typename: "page_home_Entry",
+      id: "home"
+    });
+  });
+
+  it("returns undefined when the requested CMS type is absent", () => {
+    const entries: TestEntry[] = [{}];
+
+    expect(getEntryOfType(entries, "page_home_Entry")).toBeUndefined();
+  });
+});
+
+describe("getEntriesOfType", () => {
+  it("returns only entries with the requested CMS type", () => {
+    const entries: TestEntry[] = [
+      {},
+      { __typename: "page_blogSingle_Entry", id: "first" },
+      { __typename: "page_company_Entry", id: "company" },
+      { __typename: "page_blogSingle_Entry", id: "second" }
+    ];
+
+    expect(getEntriesOfType(entries, "page_blogSingle_Entry")).toEqual([
+      { __typename: "page_blogSingle_Entry", id: "first" },
+      { __typename: "page_blogSingle_Entry", id: "second" }
+    ]);
+  });
+});

--- a/src/lib/graphql/entry-type.ts
+++ b/src/lib/graphql/entry-type.ts
@@ -1,0 +1,26 @@
+type TypedEntry = { __typename: string };
+type EntryType<TEntry> = Extract<TEntry, TypedEntry>["__typename"];
+
+export const getEntryOfType = <TEntry, TType extends EntryType<TEntry>>(
+  entries: readonly TEntry[],
+  typename: TType
+): Extract<TEntry, { __typename: TType }> | undefined =>
+  entries.find(
+    (entry): entry is Extract<TEntry, { __typename: TType }> =>
+      typeof entry === "object" &&
+      entry !== null &&
+      "__typename" in entry &&
+      (entry as TypedEntry).__typename === typename
+  );
+
+export const getEntriesOfType = <TEntry, TType extends EntryType<TEntry>>(
+  entries: readonly TEntry[],
+  typename: TType
+): Extract<TEntry, { __typename: TType }>[] =>
+  entries.filter(
+    (entry): entry is Extract<TEntry, { __typename: TType }> =>
+      typeof entry === "object" &&
+      entry !== null &&
+      "__typename" in entry &&
+      (entry as TypedEntry).__typename === typename
+  );

--- a/src/lib/rss/blog-feed.ts
+++ b/src/lib/rss/blog-feed.ts
@@ -1,9 +1,9 @@
-import type { Matrix_ContentBuilderFragment, Page_BlogSingleFragment } from "$graphql/graphql";
+import type { BlogEntry, ContentBlock } from "$lib/types/content";
 import { parse } from "node-html-parser";
 
-export type BlogFeedEntry = Page_BlogSingleFragment;
+export type BlogFeedEntry = BlogEntry;
 
-type FeedContentBlock = Matrix_ContentBuilderFragment | null | undefined;
+type FeedContentBlock = ContentBlock | null | undefined;
 type RenderableContentBlock = FeedContentBlock | Record<string, unknown>;
 
 type RssLink = {

--- a/src/lib/types/content.ts
+++ b/src/lib/types/content.ts
@@ -1,0 +1,27 @@
+import type { Asset_CustomFieldsFragment, Asset_DataFragment, Asset_TransformsFragment } from "$graphql/graphql";
+
+export type {
+  Entry_DataFragment as ContentLink,
+  Entry_DatesFragment as ContentDates,
+  Entry_SeoFragment as ContentSeo,
+  Hyper_DataFragment as Hyperlink,
+  Matrix_ContentBuilderFragment as ContentBlock,
+  Matrix_CurriculumVitaeFragment as CurriculumVitaeEntry,
+  Page_AboutFragment as AboutEntry,
+  Page_BlogListFragment as BlogListEntry,
+  Page_BlogSingleFragment as BlogEntry,
+  Page_CategoryFragment as BlogCategoryEntry,
+  Page_ContentBuilderFragment as ContentPageEntry,
+  Page_HomeFragment as HomeEntry,
+  Page_PhotosListFragment as PhotosListEntry,
+  Page_PhotosSingleFragment as PhotosEntry,
+  Page_TopicFragment as BlogTopicEntry,
+  Page_WorkListFragment as WorkListEntry,
+  Page_WorkSingleFragment as WorkEntry
+} from "$graphql/graphql";
+
+export type ImageAsset = Asset_DataFragment &
+  Partial<Asset_TransformsFragment> &
+  Partial<Asset_CustomFieldsFragment> & {
+    __typename?: string;
+  };

--- a/src/lib/utils/getFirstEntry.ts
+++ b/src/lib/utils/getFirstEntry.ts
@@ -1,6 +1,0 @@
-export const getFirstEntry = <T>(entries?: T[]): T | undefined => {
-  if (!entries || entries.length === 0) {
-    return undefined;
-  }
-  return entries[0];
-};

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,16 +1,16 @@
 import type { PageServerLoad } from "./$types";
-import { getBlogEntriesData, getHomeEntries, getPhotosEntriesData, getWorkEntriesData } from "$graphql/cms-content";
+import { getBlogPosts, getHome, getPhotoGalleries, getWorkProjects } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async () => {
-  const [entries, blog, work, photos] = await Promise.all([
-    getHomeEntries(),
-    getBlogEntriesData({ limit: 3, fullContent: false }),
-    getWorkEntriesData({ limit: 4, fullContent: false }),
-    getPhotosEntriesData({ limit: 4, fullContent: false })
+  const [entry, blog, work, photos] = await Promise.all([
+    getHome(),
+    getBlogPosts({ limit: 3, fullContent: false }),
+    getWorkProjects({ limit: 4, fullContent: false }),
+    getPhotoGalleries({ limit: 4, fullContent: false })
   ]);
 
   return {
-    entries,
+    entry,
     blogEntries: blog.entries,
     workEntries: work.entries,
     photoEntries: photos.entries

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { getFirstEntry } from "$utils/getFirstEntry";
-  import type {
-    Page_WorkSingleFragment,
-    Page_HomeFragment,
-    Page_PhotosSingleFragment,
-    Page_BlogSingleFragment
-  } from "$graphql/graphql";
   import Seo from "$components/seo/Seo.svelte";
   import Headline from "$components/text/Headline.svelte";
   import RichText from "$components/text/RichText.svelte";
@@ -21,10 +14,10 @@
   import CardPhotos from "$components/cards/Photos.svelte";
 
   let { data }: PageProps = $props();
-  let entry = getFirstEntry(data.entries) as Page_HomeFragment;
-  let blogEntries = data?.blogEntries as Page_BlogSingleFragment[];
-  let workEntries = data?.workEntries as Page_WorkSingleFragment[];
-  let photoEntries = data?.photoEntries as Page_PhotosSingleFragment[];
+  let entry = $derived(data.entry);
+  let blogEntries = $derived(data.blogEntries);
+  let workEntries = $derived(data.workEntries);
+  let photoEntries = $derived(data.photoEntries);
 
   const cc = {
     main: "w-full lg:max-w-[min(calc(100%-4vw),2000px)] mx-auto relative z-10 stack-24 pt-40 lg:pt-80 overflow-auto",

--- a/src/routes/[uri=uri]/+page.server.ts
+++ b/src/routes/[uri=uri]/+page.server.ts
@@ -1,12 +1,10 @@
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
-import { getPageByUriEntries } from "$graphql/cms-content";
+import { getPageByUri } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async ({ params }) => {
-  const entries = await getPageByUriEntries(params?.uri);
-  if (!entries.length) error(404, "Page not found");
+  const entry = await getPageByUri(params.uri);
+  if (!entry) error(404, "Page not found");
 
-  return {
-    entries
-  };
+  return { entry };
 };

--- a/src/routes/[uri=uri]/+page.svelte
+++ b/src/routes/[uri=uri]/+page.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { getFirstEntry } from "$utils/getFirstEntry";
   import Seo from "$components/seo/Seo.svelte";
   import Headline from "$components/text/Headline.svelte";
-  import { type Page_ContentBuilderFragment } from "$graphql/graphql";
 
   let { data }: PageProps = $props();
-  let entry = getFirstEntry(data.entries) as Page_ContentBuilderFragment;
+  let entry = $derived(data.entry);
 </script>
 
 {#if entry?.seomatic}

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -1,12 +1,10 @@
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
-import { getAboutEntries } from "$graphql/cms-content";
+import { getAbout } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async () => {
-  const entries = await getAboutEntries();
-  if (!entries.length) error(404, "About page not found");
+  const entry = await getAbout();
+  if (!entry) error(404, "About page not found");
 
-  return {
-    entries
-  };
+  return { entry };
 };

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { getFirstEntry } from "$utils/getFirstEntry";
-  import { type Page_AboutFragment } from "$graphql/graphql";
   import Seo from "$components/seo/Seo.svelte";
   import RichText from "$components/text/RichText.svelte";
   import Headline from "$components/text/Headline.svelte";
@@ -13,7 +11,7 @@
   import { useWaypoint } from "$lib/actions/action.waypoint";
 
   let { data }: PageProps = $props();
-  let entry = getFirstEntry(data.entries) as Page_AboutFragment;
+  let entry = $derived(data.entry);
 
   const cc = {
     heroImage: "absolute inset-x-0 top-0 z-10",

--- a/src/routes/blog/[[page=page]]/+page.server.ts
+++ b/src/routes/blog/[[page=page]]/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from "./$types";
 import { redirect } from "@sveltejs/kit";
-import { getBlogEntriesData, getBlogListPageEntries } from "$graphql/cms-content";
+import { getBlogList, getBlogPosts } from "$graphql/cms-content";
 import {
   getCanonicalFirstPageRedirect,
   getOutOfRangeRedirect,
@@ -20,8 +20,8 @@ export const load: PageServerLoad = async ({ params }) => {
 
   const offset = (page - 1) * limit;
   const [{ entries, entryCount }, blogEntry] = await Promise.all([
-    getBlogEntriesData({ limit, offset, fullContent: false }),
-    getBlogListPageEntries()
+    getBlogPosts({ limit, offset, fullContent: false }),
+    getBlogList()
   ]);
   const totalPages = getTotalPages(entryCount, limit);
   const outOfRangeRedirect = getOutOfRangeRedirect(page, totalPages, "/blog");

--- a/src/routes/blog/[[page=page]]/+page.svelte
+++ b/src/routes/blog/[[page=page]]/+page.svelte
@@ -3,16 +3,13 @@
   import StackBlog from "$components/stacks/Blog.svelte";
   import RichText from "$components/text/RichText.svelte";
   import Seo from "$components/seo/Seo.svelte";
-  import { getFirstEntry } from "$utils/getFirstEntry";
   import { useSplitText } from "$lib/actions/action.splitText";
-
-  import { type Page_BlogSingleFragment, type Page_BlogListFragment } from "$graphql/graphql";
 
   let { data }: PageProps = $props();
   const entryCount = data.entryCount ?? 1;
   const totalPages = data.totalPages ?? 1;
-  let blogEntry = $derived(getFirstEntry(data.blogEntry) as Page_BlogListFragment);
-  let entries = $derived(data.entries as Page_BlogSingleFragment[]);
+  let blogEntry = $derived(data.blogEntry);
+  let entries = $derived(data.entries);
   let page = $derived(data.page);
 
   const cc = {
@@ -36,7 +33,7 @@
         {/each}
       </h1>
     {/if}
-    {#if blogEntry.description}
+    {#if blogEntry?.description}
       <RichText className={cc.text} html={blogEntry.description} data-waypoint-target />
     {/if}
   {:else}

--- a/src/routes/blog/[slug=slug].md/+server.ts
+++ b/src/routes/blog/[slug=slug].md/+server.ts
@@ -1,10 +1,10 @@
 import type { RequestHandler } from "./$types";
-import { getBlogEntriesData } from "$graphql/cms-content";
+import { getBlogPosts } from "$graphql/cms-content";
 import { renderBlog } from "$lib/ai/blog";
 import { mdResponse, notFound } from "$lib/ai/helpers";
 
 export const GET: RequestHandler = async ({ params }) => {
-  const { entries } = await getBlogEntriesData({ slug: [params.slug!], limit: 1, fullContent: true });
+  const { entries } = await getBlogPosts({ slug: [params.slug], limit: 1, fullContent: true });
   const entry = entries[0];
   return entry ? mdResponse(renderBlog(entry)) : notFound();
 };

--- a/src/routes/blog/[slug=slug]/+page.server.ts
+++ b/src/routes/blog/[slug=slug]/+page.server.ts
@@ -1,12 +1,10 @@
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
-import { getBlogEntriesData } from "$graphql/cms-content";
+import { getBlogPosts } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async ({ params }) => {
-  const { entries } = await getBlogEntriesData({ slug: [params.slug!], limit: 1, fullContent: true });
+  const { entries } = await getBlogPosts({ slug: [params.slug], limit: 1, fullContent: true });
   const entry = entries[0];
   if (!entry) error(404, "Blog post not found");
-  return {
-    entries
-  };
+  return { entry };
 };

--- a/src/routes/blog/[slug=slug]/+page.svelte
+++ b/src/routes/blog/[slug=slug]/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { getFirstEntry } from "$utils/getFirstEntry";
-  import type { Page_BlogSingleFragment } from "$graphql/graphql";
   import Seo from "$components/seo/Seo.svelte";
   import HeroBlog from "$components/heros/Blog.svelte";
   import ContentBuilder from "$components/builders/ContentBuilder.svelte";
@@ -9,7 +7,7 @@
 
   let { data }: PageProps = $props();
 
-  const entry = $derived(getFirstEntry(data.entries) as Page_BlogSingleFragment);
+  const entry = $derived(data.entry);
 </script>
 
 {#if entry?.seomatic}

--- a/src/routes/blog/c/[slug=slug]/[[page=page]]/+page.server.ts
+++ b/src/routes/blog/c/[slug=slug]/[[page=page]]/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from "./$types";
 import { error, redirect } from "@sveltejs/kit";
-import { getBlogEntriesData, getCategoryEntries } from "$graphql/cms-content";
+import { getBlogCategory, getBlogPosts } from "$graphql/cms-content";
 import {
   getCanonicalFirstPageRedirect,
   getOutOfRangeRedirect,
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async ({ params }) => {
   const offset = (page - 1) * limit || 0;
 
   const [{ entries, entryCount }, categoryEntry] = await Promise.all([
-    getBlogEntriesData({
+    getBlogPosts({
       relatedToEntries: [
         {
           section: ["categories"],
@@ -26,14 +26,14 @@ export const load: PageServerLoad = async ({ params }) => {
       offset,
       fullContent: false
     }),
-    getCategoryEntries(params?.slug)
+    getBlogCategory(params.slug)
   ]);
 
-  if (!categoryEntry.length) error(404, "Blog category not found");
+  if (!categoryEntry) error(404, "Blog category not found");
 
   const totalPages = getTotalPages(entryCount, limit);
 
-  const canonicalPath = categoryEntry?.[0]?.uri ? `/${categoryEntry[0].uri}` : undefined;
+  const canonicalPath = categoryEntry.uri ? `/${categoryEntry.uri}` : undefined;
   const canonicalRedirect = getCanonicalFirstPageRedirect(page, params.page, canonicalPath);
   const outOfRangeRedirect = getOutOfRangeRedirect(page, totalPages, canonicalPath);
 

--- a/src/routes/blog/c/[slug=slug]/[[page=page]]/+page.svelte
+++ b/src/routes/blog/c/[slug=slug]/[[page=page]]/+page.svelte
@@ -3,18 +3,15 @@
   import StackBlog from "$components/stacks/Blog.svelte";
   import RichText from "$components/text/RichText.svelte";
   import Seo from "$components/seo/Seo.svelte";
-  import { getFirstEntry } from "$utils/getFirstEntry";
   import { splitTextIntoDivs } from "$utils/splitTextIntoDivs";
   import { useWaypoint } from "$lib/actions/action.waypoint";
   import { useJumpingLetters } from "$lib/actions/action.jumpingLetters";
 
-  import { type Page_BlogSingleFragment, type Page_CategoryFragment } from "$graphql/graphql";
-
   let { data }: PageProps = $props();
   const entryCount = data.entryCount ?? 1;
   const totalPages = data.totalPages ?? 1;
-  let categoryEntry = $derived(getFirstEntry(data.categoryEntry) as Page_CategoryFragment);
-  let entries = $derived(data.entries as Page_BlogSingleFragment[]);
+  let categoryEntry = $derived(data.categoryEntry);
+  let entries = $derived(data.entries);
   let page = $derived(data.page);
 
   const cc = {

--- a/src/routes/blog/t/[slug=slug]/[[page=page]]/+page.server.ts
+++ b/src/routes/blog/t/[slug=slug]/[[page=page]]/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from "./$types";
 import { error, redirect } from "@sveltejs/kit";
-import { getBlogEntriesData, getTopicEntries } from "$graphql/cms-content";
+import { getBlogPosts, getBlogTopic } from "$graphql/cms-content";
 import {
   getCanonicalFirstPageRedirect,
   getOutOfRangeRedirect,
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async ({ params }) => {
   const offset = (page - 1) * limit || 0;
 
   const [{ entries, entryCount }, topicEntry] = await Promise.all([
-    getBlogEntriesData({
+    getBlogPosts({
       relatedToEntries: [
         {
           section: ["topics"],
@@ -26,14 +26,14 @@ export const load: PageServerLoad = async ({ params }) => {
       offset,
       fullContent: false
     }),
-    getTopicEntries(params?.slug)
+    getBlogTopic(params.slug)
   ]);
 
-  if (!topicEntry.length) error(404, "Blog topic not found");
+  if (!topicEntry) error(404, "Blog topic not found");
 
   const totalPages = getTotalPages(entryCount, limit);
 
-  const canonicalPath = topicEntry?.[0]?.uri ? `/${topicEntry[0].uri}` : undefined;
+  const canonicalPath = topicEntry.uri ? `/${topicEntry.uri}` : undefined;
   const canonicalRedirect = getCanonicalFirstPageRedirect(page, params.page, canonicalPath);
   const outOfRangeRedirect = getOutOfRangeRedirect(page, totalPages, canonicalPath);
 

--- a/src/routes/blog/t/[slug=slug]/[[page=page]]/+page.svelte
+++ b/src/routes/blog/t/[slug=slug]/[[page=page]]/+page.svelte
@@ -3,18 +3,15 @@
   import StackBlog from "$components/stacks/Blog.svelte";
   import RichText from "$components/text/RichText.svelte";
   import Seo from "$components/seo/Seo.svelte";
-  import { getFirstEntry } from "$utils/getFirstEntry";
   import { splitTextIntoDivs } from "$utils/splitTextIntoDivs";
   import { useWaypoint } from "$lib/actions/action.waypoint";
   import { useJumpingLetters } from "$lib/actions/action.jumpingLetters";
 
-  import { type Page_BlogSingleFragment, type Page_TopicFragment } from "$graphql/graphql";
-
   let { data }: PageProps = $props();
   const entryCount = data.entryCount ?? 1;
   const totalPages = data.totalPages ?? 1;
-  let topicEntry = $derived(getFirstEntry(data.topicEntry) as Page_TopicFragment);
-  let entries = $derived(data.entries as Page_BlogSingleFragment[]);
+  let topicEntry = $derived(data.topicEntry);
+  let entries = $derived(data.entries);
   let page = $derived(data.page);
 
   const cc = {

--- a/src/routes/llms-full.txt/+server.ts
+++ b/src/routes/llms-full.txt/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from "./$types";
 import { SITE_URL } from "$lib/ai/helpers";
-import { getBlogEntriesData, getWorkEntriesData } from "$graphql/cms-content";
+import { getBlogPosts, getWorkProjects } from "$graphql/cms-content";
 
 type Entry = {
   slug?: string | null;
@@ -18,8 +18,8 @@ const line = (e: Entry, section: "blog" | "work") => {
 
 export const GET: RequestHandler = async () => {
   const [blogData, workData] = await Promise.all([
-    getBlogEntriesData({ limit: 1000, fullContent: false }),
-    getWorkEntriesData({ limit: 1000, fullContent: false })
+    getBlogPosts({ limit: 1000, fullContent: false }),
+    getWorkProjects({ limit: 1000, fullContent: false })
   ]);
   const blog = blogData.entries as Entry[];
   const work = workData.entries as Entry[];

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from "./$types";
-import { getBlogEntriesData, getWorkEntriesData } from "$graphql/cms-content";
+import { getBlogPosts, getWorkProjects } from "$graphql/cms-content";
 import { SITE_URL } from "$lib/ai/helpers";
 
 type Entry = {
@@ -18,8 +18,8 @@ const line = (e: Entry, section: "blog" | "work") => {
 
 export const GET: RequestHandler = async () => {
   const [blogData, workData] = await Promise.all([
-    getBlogEntriesData({ limit: 12, fullContent: false }),
-    getWorkEntriesData({ limit: 100, fullContent: false })
+    getBlogPosts({ limit: 12, fullContent: false }),
+    getWorkProjects({ limit: 100, fullContent: false })
   ]);
   const latestBlog = blogData.entries as Entry[];
   const work = workData.entries as Entry[];

--- a/src/routes/photos/[[page=page]]/+page.server.ts
+++ b/src/routes/photos/[[page=page]]/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from "./$types";
 import { redirect } from "@sveltejs/kit";
-import { getPhotosEntriesData, getPhotosListPageEntries } from "$graphql/cms-content";
+import { getPhotoGalleries, getPhotosList } from "$graphql/cms-content";
 import {
   getCanonicalFirstPageRedirect,
   getOutOfRangeRedirect,
@@ -20,8 +20,8 @@ export const load: PageServerLoad = async ({ params }) => {
 
   const offset = (page - 1) * limit;
   const [{ entries, entryCount }, photosEntry] = await Promise.all([
-    getPhotosEntriesData({ limit, offset, fullContent: false, listContent: true }),
-    getPhotosListPageEntries()
+    getPhotoGalleries({ limit, offset, fullContent: false, listContent: true }),
+    getPhotosList()
   ]);
   const totalPages = getTotalPages(entryCount, limit);
   const outOfRangeRedirect = getOutOfRangeRedirect(page, totalPages, "/photos");

--- a/src/routes/photos/[[page=page]]/+page.svelte
+++ b/src/routes/photos/[[page=page]]/+page.svelte
@@ -3,17 +3,14 @@
   import StackPhotos from "$components/stacks/Photos.svelte";
   import RichText from "$components/text/RichText.svelte";
   import Seo from "$components/seo/Seo.svelte";
-  import { getFirstEntry } from "$utils/getFirstEntry";
   import { useSplitText } from "$lib/actions/action.splitText";
-
-  import { type Page_PhotosSingleFragment, type Page_PhotosListFragment } from "$graphql/graphql";
 
   let { data }: PageProps = $props();
 
   const entryCount = data.entryCount ?? 1;
   const totalPages = data.totalPages ?? 1;
-  let photosEntry = $derived(getFirstEntry(data.photosEntry) as Page_PhotosListFragment);
-  let entries = $derived(data.entries) as Page_PhotosSingleFragment[];
+  let photosEntry = $derived(data.photosEntry);
+  let entries = $derived(data.entries);
   let page = $derived(data.page);
 
   const cc = {

--- a/src/routes/photos/[slug=slug]/+page.server.ts
+++ b/src/routes/photos/[slug=slug]/+page.server.ts
@@ -1,12 +1,10 @@
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
-import { getPhotosEntriesData } from "$graphql/cms-content";
+import { getPhotoGalleries } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async ({ params }) => {
-  const { entries } = await getPhotosEntriesData({ slug: [params.slug!], limit: 1, fullContent: true });
+  const { entries } = await getPhotoGalleries({ slug: [params.slug], limit: 1, fullContent: true });
   const entry = entries[0];
   if (!entry) error(404, "Photo gallery not found");
-  return {
-    entries
-  };
+  return { entry };
 };

--- a/src/routes/photos/[slug=slug]/+page.svelte
+++ b/src/routes/photos/[slug=slug]/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { getFirstEntry } from "$utils/getFirstEntry";
-  import type { Page_PhotosSingleFragment } from "$graphql/graphql";
   import Seo from "$components/seo/Seo.svelte";
   import HeroPhotos from "$components/heros/Photos.svelte";
   import LightboxPhotos from "$components/modals/LightboxPhotos.svelte";
@@ -10,7 +8,7 @@
 
   let { data }: PageProps = $props();
 
-  const entry = $derived(getFirstEntry(data.entries) as Page_PhotosSingleFragment);
+  const entry = $derived(data.entry);
   const exifDataParsed = $derived(entry?.images ? getExifData(entry.images) : undefined);
 </script>
 

--- a/src/routes/rss.xml/+server.ts
+++ b/src/routes/rss.xml/+server.ts
@@ -1,9 +1,9 @@
 import type { RequestHandler } from "./$types";
-import { getBlogEntriesData } from "$graphql/cms-content";
+import { getBlogPosts } from "$graphql/cms-content";
 import { renderBlogRssFeed } from "$lib/rss/blog-feed";
 import { createRssXmlResponse } from "$lib/rss/response";
 
 export const GET: RequestHandler = async () => {
-  const { entries } = await getBlogEntriesData({ limit: 20, fullContent: true });
+  const { entries } = await getBlogPosts({ limit: 20, fullContent: true });
   return createRssXmlResponse(renderBlogRssFeed(entries));
 };

--- a/src/routes/work/+page.server.ts
+++ b/src/routes/work/+page.server.ts
@@ -1,11 +1,8 @@
 import type { PageServerLoad } from "./$types";
-import { getWorkEntriesData, getWorkListPageEntries } from "$graphql/cms-content";
+import { getWorkList, getWorkProjects } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async () => {
-  const [workEntry, work] = await Promise.all([
-    getWorkListPageEntries(),
-    getWorkEntriesData({ limit: 100, fullContent: false })
-  ]);
+  const [workEntry, work] = await Promise.all([getWorkList(), getWorkProjects({ limit: 100, fullContent: false })]);
 
   return {
     workEntry,

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import type { Page_WorkListFragment, Page_WorkSingleFragment } from "$graphql/graphql";
   import Seo from "$components/seo/Seo.svelte";
   import GridBentoWork from "$components/containers/GridBentoWork.svelte";
-  import { getFirstEntry } from "$utils/getFirstEntry";
   import { useSplitText } from "$lib/actions/action.splitText";
 
   let { data }: PageProps = $props();
-  let workEntry = getFirstEntry(data.workEntry) as Page_WorkListFragment;
-  let workEntries = data?.workEntries as Page_WorkSingleFragment[];
+  let workEntry = $derived(data.workEntry);
+  let workEntries = $derived(data.workEntries);
 
   const cc = {
     heading: "span-content text-neon-pink text-7xl font-decorative font-extrabold",

--- a/src/routes/work/[slug=slug].md/+server.ts
+++ b/src/routes/work/[slug=slug].md/+server.ts
@@ -1,10 +1,10 @@
 import type { RequestHandler } from "./$types";
-import { getWorkEntriesData } from "$graphql/cms-content";
+import { getWorkProjects } from "$graphql/cms-content";
 import { renderWork } from "$lib/ai/work";
 import { mdResponse, notFound } from "$lib/ai/helpers";
 
 export const GET: RequestHandler = async ({ params }) => {
-  const { entries } = await getWorkEntriesData({ slug: [params.slug!], limit: 1, fullContent: true });
+  const { entries } = await getWorkProjects({ slug: [params.slug], limit: 1, fullContent: true });
   const entry = entries[0];
   return entry ? mdResponse(renderWork(entry)) : notFound();
 };

--- a/src/routes/work/[slug=slug]/+page.server.ts
+++ b/src/routes/work/[slug=slug]/+page.server.ts
@@ -1,12 +1,10 @@
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
-import { getWorkEntriesData } from "$graphql/cms-content";
+import { getWorkProjects } from "$graphql/cms-content";
 
 export const load: PageServerLoad = async ({ params }) => {
-  const { entries } = await getWorkEntriesData({ slug: [params.slug!], limit: 1, fullContent: true });
+  const { entries } = await getWorkProjects({ slug: [params.slug], limit: 1, fullContent: true });
   const entry = entries[0];
   if (!entry) error(404, "Work entry not found");
-  return {
-    entries
-  };
+  return { entry };
 };

--- a/src/routes/work/[slug=slug]/+page.svelte
+++ b/src/routes/work/[slug=slug]/+page.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { getFirstEntry } from "$utils/getFirstEntry";
-  import type { Page_WorkSingleFragment } from "$graphql/graphql";
   import Seo from "$components/seo/Seo.svelte";
   import HeroWork from "$components/heros/Work.svelte";
   import PrevNext from "$components/navigation/PrevNext.svelte";
   import WorkMedia from "$components/sections/WorkMedia.svelte";
 
   let { data }: PageProps = $props();
-  const entry = $derived(getFirstEntry(data.entries) as Page_WorkSingleFragment);
+  const entry = $derived(data.entry);
 </script>
 
 {#if entry?.seomatic}

--- a/src/routes/work/page-server.test.ts
+++ b/src/routes/work/page-server.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const cmsMocks = vi.hoisted(() => ({
-  getWorkEntriesData: vi.fn(),
-  getWorkListPageEntries: vi.fn()
+  getWorkList: vi.fn(),
+  getWorkProjects: vi.fn()
 }));
 
 vi.mock("$graphql/cms-content", () => cmsMocks);
@@ -11,14 +11,14 @@ import { load } from "./+page.server";
 
 describe("work page server load", () => {
   beforeEach(() => {
-    cmsMocks.getWorkListPageEntries.mockResolvedValue([]);
-    cmsMocks.getWorkEntriesData.mockResolvedValue({ entries: [] });
+    cmsMocks.getWorkList.mockResolvedValue(undefined);
+    cmsMocks.getWorkProjects.mockResolvedValue({ entries: [] });
   });
 
   it("uses a positive Craft-compatible collection limit", async () => {
     await load({} as never);
 
-    expect(cmsMocks.getWorkEntriesData).toHaveBeenCalledWith({
+    expect(cmsMocks.getWorkProjects).toHaveBeenCalledWith({
       limit: 100,
       fullContent: false
     });


### PR DESCRIPTION
## Summary

- Refactor content block and media rendering across pages, stacks, and sections
- Introduce shared entry-type handling and content utilities
- Add and update AI-readable content, RSS, Markdown, and `llms.txt` endpoints
- Simplify route data loading and page component composition
- Update related tests and content type definitions

## Testing

Not run (not requested)