### PR TITLE
Prevent SplitText heading flash during client load

### DIFF
--- a/src/lib/actions/action.splitText.test.ts
+++ b/src/lib/actions/action.splitText.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
   });
 
   return {
+    set: vi.fn(),
     splitTextCreate,
     timeline: vi.fn(() => ({
       fromTo: vi.fn(),
@@ -32,7 +33,7 @@ const mocks = vi.hoisted(() => {
 vi.mock("gsap", () => ({
   gsap: {
     registerPlugin: vi.fn(),
-    set: vi.fn(),
+    set: mocks.set,
     timeline: mocks.timeline,
     utils: { random: vi.fn(() => 1) }
   }
@@ -47,7 +48,9 @@ import { useSplitText } from "./action.splitText";
 type TestNode = {
   childNodes: Array<{ nodeType: number; textContent: string }>;
   getBoundingClientRect: () => { height: number };
+  hidden: boolean;
   normalize: () => void;
+  removeAttribute: (name: string) => void;
 };
 
 class TestIntersectionObserver {
@@ -72,6 +75,7 @@ class TestIntersectionObserver {
 describe("useSplitText", () => {
   beforeEach(() => {
     mocks.splitTextCreate.mockClear();
+    mocks.set.mockClear();
     mocks.timeline.mockClear();
     TestIntersectionObserver.current = undefined;
 
@@ -95,8 +99,12 @@ describe("useSplitText", () => {
         { nodeType: 3, textContent: "" }
       ],
       getBoundingClientRect: () => ({ height: 120 }),
+      hidden: true,
       normalize() {
         this.childNodes = this.childNodes.filter((child) => child.nodeType !== 3 || child.textContent !== "");
+      },
+      removeAttribute(name) {
+        if (name === "hidden") this.hidden = false;
       }
     };
 
@@ -105,5 +113,41 @@ describe("useSplitText", () => {
 
     expect(() => TestIntersectionObserver.current?.trigger()).not.toThrow();
     expect(mocks.splitTextCreate).toHaveBeenCalledOnce();
+  });
+
+  it("makes the server-hidden heading transparent before revealing its layout", () => {
+    const removeAttribute = vi.fn();
+    const node: TestNode = {
+      childNodes: [{ nodeType: 3, textContent: "Frontier AI." }],
+      getBoundingClientRect: () => ({ height: 120 }),
+      hidden: true,
+      normalize() {},
+      removeAttribute
+    };
+
+    useSplitText(node as unknown as HTMLElement);
+
+    expect(mocks.set).toHaveBeenCalledWith(node, { opacity: 0 });
+    expect(removeAttribute).toHaveBeenCalledWith("hidden");
+    expect(mocks.set.mock.invocationCallOrder[0]).toBeLessThan(removeAttribute.mock.invocationCallOrder[0]);
+  });
+
+  it("reveals the server-hidden heading immediately when reduced motion is preferred", () => {
+    vi.stubGlobal("window", {
+      matchMedia: (query: string) => ({ matches: query.includes("prefers-reduced-motion") })
+    });
+    const removeAttribute = vi.fn();
+    const node: TestNode = {
+      childNodes: [{ nodeType: 3, textContent: "Frontier AI." }],
+      getBoundingClientRect: () => ({ height: 120 }),
+      hidden: true,
+      normalize() {},
+      removeAttribute
+    };
+
+    useSplitText(node as unknown as HTMLElement);
+
+    expect(removeAttribute).toHaveBeenCalledWith("hidden");
+    expect(mocks.set).not.toHaveBeenCalledWith(node, { opacity: 0 });
   });
 });

--- a/src/lib/actions/action.splitText.ts
+++ b/src/lib/actions/action.splitText.ts
@@ -21,10 +21,12 @@ export function useSplitText(
   let destroyed = false;
 
   const canJump = jumpingLetters && window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+  const reveal = () => node.removeAttribute("hidden");
 
   const restore = () => {
     if (split?.isSplit) split.revert();
     gsap.set(node, { clearProps: "height,opacity" });
+    reveal();
   };
 
   const play = () => {
@@ -174,26 +176,38 @@ export function useSplitText(
   };
 
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    reveal();
     return;
   }
 
+  // The SSR markup stays hidden until the client has applied its transparent
+  // initial state. Both operations are synchronous, so there is no visible
+  // frame between revealing the layout and starting SplitText.
   gsap.set(node, { opacity: 0 });
+  reveal();
 
-  document.fonts.ready.then(() => {
-    if (destroyed) return;
+  document.fonts.ready
+    .then(() => {
+      if (destroyed) return;
 
-    observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) return;
+      observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
 
-        observer?.disconnect();
-        play();
-      },
-      { threshold: 0.1 }
-    );
+          observer?.disconnect();
 
-    observer.observe(node);
-  });
+          try {
+            play();
+          } catch {
+            restore();
+          }
+        },
+        { threshold: 0.1 }
+      );
+
+      observer.observe(node);
+    })
+    .catch(restore);
 
   return {
     destroy() {

--- a/src/lib/components/text/Headline.svelte
+++ b/src/lib/components/text/Headline.svelte
@@ -52,12 +52,16 @@
     splitText,
     ...rest
   }: HeadlineProps = $props();
+
+  let hasSplitText = $derived(splitTextAction !== noAction);
 </script>
 
 {#if text}
   <svelte:element
     this={tag}
     data-comp={compName}
+    data-split-text={hasSplitText ? "" : undefined}
+    hidden={hasSplitText}
     class={tvHeadline({ preset, family, className })}
     use:splitTextAction={splitText}
     {...rest}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,7 +62,7 @@
   <div class="fluid-grid">
     <Glass preset="glass-home" className={cc.glass}>
       {#if entry?.customTitle}
-        <h1 class={cc.heroHeadline} use:useSplitText={{ direction: "fromTop" }}>
+        <h1 data-split-text hidden class={cc.heroHeadline} use:useSplitText={{ direction: "fromTop" }}>
           {#each entry.customTitle.split("$") as line, index (`${line}-${index}`)}
             {#if index > 0}<br />{/if}
             {line}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -44,7 +44,7 @@
 <div class="fluid-grid">
   <Glass preset="glass-home" className={cc.glass}>
     {#if entry?.customTitle}
-      <h1 class={cc.heroHeadline} use:useSplitText={{ direction: "fromTop" }}>
+      <h1 data-split-text hidden class={cc.heroHeadline} use:useSplitText={{ direction: "fromTop" }}>
         {#each entry.customTitle.split("$") as line, index (`${line}-${index}`)}
           {#if index > 0}<br />{/if}
           {line}

--- a/src/routes/blog/[[page=page]]/+page.svelte
+++ b/src/routes/blog/[[page=page]]/+page.svelte
@@ -29,7 +29,7 @@
 {#key page}
   {#if page === 1}
     {#if blogEntry?.customTitle}
-      <h1 class={cc.heading} use:useSplitText={{ direction: "fromTop" }}>
+      <h1 data-split-text hidden class={cc.heading} use:useSplitText={{ direction: "fromTop" }}>
         {#each blogEntry.customTitle.split("$") as line, index (`${line}-${index}`)}
           {#if index > 0}<br />{/if}
           {line}
@@ -41,6 +41,8 @@
     {/if}
   {:else}
     <h1
+      data-split-text
+      hidden
       class="span-content text-neon-pink font-decorative text-7xl font-extrabold"
       use:useSplitText={{ direction: "fromTop" }}
     >

--- a/src/routes/photos/[[page=page]]/+page.svelte
+++ b/src/routes/photos/[[page=page]]/+page.svelte
@@ -31,7 +31,7 @@
   {#key page}
     {#if page === 1}
       {#if photosEntry?.customTitle}
-        <h1 class={cc.heading} use:useSplitText={{ direction: "fromTop" }}>
+        <h1 data-split-text hidden class={cc.heading} use:useSplitText={{ direction: "fromTop" }}>
           {#each photosEntry.customTitle.split("$") as line, index (`${line}-${index}`)}
             {#if index > 0}<br />{/if}
             {line}
@@ -43,6 +43,8 @@
       {/if}
     {:else}
       <h1
+        data-split-text
+        hidden
         class="span-content text-black font-decorative text-7xl font-extrabold"
         use:useSplitText={{ direction: "fromTop" }}
       >

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -22,7 +22,7 @@
 {/if}
 
 {#if workEntry?.customTitle}
-  <h1 class={cc.heading} use:useSplitText={{ direction: "fromTop" }}>
+  <h1 data-split-text hidden class={cc.heading} use:useSplitText={{ direction: "fromTop" }}>
     {#each workEntry.customTitle.split("$") as line, index (`${line}-${index}`)}
       {#if index > 0}<br />{/if}
       {line}


### PR DESCRIPTION
## Summary
- Keep SplitText headings hidden during SSR until their initial animation state is applied.
- Reveal headings safely for reduced-motion users and animation failures.
- Add regression tests covering reveal ordering and reduced-motion behavior.

## Testing
- Added unit tests for SplitText visibility handling.
- Not run (not requested).